### PR TITLE
Correct instructions to verify in-house SSL CA Certificate.

### DIFF
--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -182,12 +182,4 @@ longdateformat: %d.%m.%Y
 datetimeformat: %d.%m. %H:%M
 longdatetimeformat: %d.%m.%Y %H:%M
 
-# the encoding of your terminal emulator
-# encoding: utf-8
-
-# by default, khal uses unicode symbols to display certain event properties set
-# to False if you do not want this (e.g. your character set does not support
-# these symbols
-# unicode_symbols: True
-
 DEBUG: 0


### PR DESCRIPTION
Ya, kind of wordy but the combination of the hard to see back ticks and DotZERO leaves lots of room for error.

Also, I don't the PEM method works for anyone. OpenSSL requires them to be named the same value as their hash made in that strange way. It is important to push this upstream. Many, many people and organizations use in-hose PKI systems.

Public CA's have proven themselves to be untrustworthy, and it's free.

-- I also created an Archlinux PKGBUILD, but I don't expect you to pull that. On second though, it may serve to be a good example. At least I hope it is good :p
