### PR TITLE
khal.conf.sample :  Rewritten: complete, clean, and includes Self-Sign/Corp-PKI CA Cert verify

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,3 +1,4 @@
 Christian Geier
 David Soulayrol - david.soulayrol [at] gmail [dot] com - http://david.soulayrol.name
 Aaron Bishop - abishop [at] linux [dot] com
+Thomas Dwyer - github [at] tomd [dot] tel - http://tomd.tel

--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -17,6 +17,11 @@
 # # Each Account configuration must start with an Account Tag
 # # Each Account Tag must be unique
 #
+# write_support: YesPleaseIDoHaveABackupOfMyData
+# # Enable writing events and event changes to CalDAV Server
+# #   * Default: Disabled
+# #   * Make Sure you have a Backup of your calender before enabling
+#
 # type: caldav
 # # Set the protocol khal should use
 # #  * Default: caldav
@@ -126,7 +131,6 @@
 # # It is also used if vCal datetimes or timezone is not understood
 # #
 #
-#
 # timeformat: %H:%M
 # dateformat: %m-%d
 # longdateformat: %Y-%m-%d
@@ -134,10 +138,19 @@
 # longdatetimeformat: %Y-%m-%d %H:%M
 # # Siet the format Time and Date should be displayed in khal
 # #   * Long version should contain the current year
-#
+# #
 # # Specify date/time in standard strftime format
 # # http://strftime.net/
 # #   * Example date in ISO-8601 format, "American"
+#
+# encoding: utf-8
+# # Enable UTF-8 encoding
+# #   * Set this if your terminal is using to utf-8
+#
+# unicode_symbols: True
+# # Enable unicode symbols to display event properties
+# # Set this to False if your terminal's character set dose not support them
+# #   * Default: True
 #
 #------------------------------------------------------------------------------
 # ## Debug Level ##
@@ -152,6 +165,7 @@
 ## Example Configuration
 ##
 [Account home]
+write_support: YesPleaseIDoHaveABackupOfMyData
 user: jdoe
 passwd: 2342
 resource: https://exmaple.com/davical/caldav.php/jdoe/home/


### PR DESCRIPTION
Aloha,

I've rewritten the sample configuration file.
I found it to be kind of hard to follow before. This new file contains all the information form the old file but in a much cleaner way. It also includes instructions for verifying Self-Signed or Corporate PKI CA Certificates.

First, I define default location for khal.conf
Second, outline the sections of the configuration file
Third, step through each section, section by section & option by option. Explaining each section and option along the way.

There is the sample configuration at the bottom. However, with all comments removed. The comments were removed because everything has already been defined. With them removed the example is much easier to follow. 
