### PR TITLE
Add missing Content-Type header to Syncer

### DIFF
--- a/khal/caldav.py
+++ b/khal/caldav.py
@@ -161,6 +161,7 @@ class Syncer(object):
             from requests.auth import HTTPDigestAuth
             self._settings['auth'] = HTTPDigestAuth(user, passwd)
         self._default_headers = {"User-Agent": "khal"}
+        self._default_headers["Content-Type"] = "application/xml; charset=UTF-8"
 
         headers = self.headers
         headers['Depth'] = '1'


### PR DESCRIPTION
The Google CalDav API currently returns a 400 status code when used with khal.
The error disappears if a Content-Type header is specified.
With this fix applied, khal now seems to be working fine with Google Calendar.
