### PR TITLE
Expand environment variables in config, fix sample config to match

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ David Soulayrol - david.soulayrol [at] gmail [dot] com - http://david.soulayrol.
 Aaron Bishop - abishop [at] linux [dot] com
 Thomas Dwyer - github [at] tomd [dot] tel - http://tomd.tel
 Thomas Tschager - github [at] tschager [dot] net - https://thomas.tschager.net
+Patrice Peterson - runiq [at] archlinux [dot] us

--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -2,7 +2,7 @@
 #
 # The default configuration file locations are:
 # ~/.khal/khal.conf
-# ~/.config/khal/khal.conf
+# $XDG_CONFIG_HOME/khal/khal.conf
 #
 # In this file you need to specify:
 # - CalDAV Account settings
@@ -44,7 +44,7 @@
 # 
 # path: ~/.khal/khal.db
 # # This specifies the location of the khal SQLite3 Database file
-# #   * Default: ~/.local/share/khal/khal.db
+# #   * Default: $XDG_CACHE_HOME/khal/khal.db
 #
 #------------------------------------------------------------------------------
 # ## Time Zone and Time Display Formating Configuration ##

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -227,7 +227,7 @@ class CalendarSection(Section):
     def __init__(self, parser):
         Section.__init__(self, parser, 'calendars')
         self._schema = [
-            ('path', None, os.path.expanduser),
+            ('path', None, lambda x: os.path.expanduser(os.path.expandvars(x))),
             ('readonly', False, self._parse_bool_string),
             ('color', '', None)
         ]
@@ -248,7 +248,7 @@ class SQLiteSection(Section):
         Section.__init__(self, parser, 'sqlite')
         default_path = xdg.BaseDirectory.xdg_cache_home + '/khal/khal.db'
         self._schema = [
-            ('path', default_path, os.path.expanduser),
+            ('path', default_path, lambda x: os.path.expanduser(os.path.expandvars(x))),
         ]
 
 


### PR DESCRIPTION
The default config values for the sqlite path already makes use of the
XDG basedir spec.  However, user-supplied paths with environment
variables (either for the sqlite path or for calendar paths) were not
expanded before. This patch allows to use environment variables in these
config settings.

It also fixes the documentation so it mentions the XDG variables it
uses.
