### PR TITLE
fixing: "ImportError: No module named khal"

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -14,6 +14,8 @@
 
 import sys
 import os
+
+sys.path.insert(0, os.path.abspath('../../../khal'))
 from khal import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,


### PR DESCRIPTION
"ImportError: No module named khal" occurs at build if khal is not already installed in the default python libraries.
Btw, source code module should be used even if khal module exists on the build machine.
