### PR TITLE
crude fix for:

### DIFF
--- a/khal/khalendar/aux.py
+++ b/khal/khalendar/aux.py
@@ -132,6 +132,11 @@ def sanitize(vevent, default_timezone, href='', calendar=''):
     # TODO do this for everything where a TZID can appear (RDATE, EXDATE,
     # RRULE:UNTIL)
     for prop in ['DTSTART', 'DTEND', 'DUE', 'RECURRENCE-ID']:
+        if prop=='DTEND' and isinstance(vevent[prop], list):
+            value = vevent[prop][1]
+            vevent.pop(prop)
+            vevent.add(prop, value)
+
         if prop in vevent and invalid_timezone(vevent[prop]):
             value = default_timezone.localize(vevent.pop(prop).dt)
             vevent.add(prop, value)
@@ -223,7 +228,7 @@ def to_naive_utc(dtime):
 def invalid_timezone(prop):
     """check if a icalendar property has a timezone attached we don't understand"""
     if not hasattr(prop, 'dt'):
-        return False
+        return True
     if hasattr(prop.dt, 'tzinfo') and prop.dt.tzinfo is None and 'TZID' in prop.params:
         return True
     else:

--- a/khal/khalendar/aux.py
+++ b/khal/khalendar/aux.py
@@ -162,6 +162,13 @@ def sanitize_timerange(dtstart, dtend, duration=None):
             dtstart = dtstart.date()
         dtend = dtstart + timedelta(days=1)
     elif dtend is not None:
+        utc = pytz.UTC
+
+        if hasattr(dtend, 'tzinfo') and dtend.tzinfo is not None:
+            dtend = dtend.replace(tzinfo=None)
+        if hasattr(dtstart, 'tzinfo') and dtstart.tzinfo is not None:
+            dtstart = dtstart.replace(tzinfo=None)
+
         if dtend < dtstart:
             raise ValueError('The event\'s end time (DTEND) is older than '
                              'the event\'s start time (DTSTART).')
@@ -215,6 +222,8 @@ def to_naive_utc(dtime):
 
 def invalid_timezone(prop):
     """check if a icalendar property has a timezone attached we don't understand"""
+    if not hasattr(prop, 'dt'):
+        return False
     if hasattr(prop.dt, 'tzinfo') and prop.dt.tzinfo is None and 'TZID' in prop.params:
         return True
     else:

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -454,7 +454,10 @@ class FloatingEvent(DatetimeEvent):
 
     @property
     def end_local(self):
-        return self._locale['local_timezone'].localize(self.end)
+        if(self.end.tzinfo is not None):
+            return self.end
+        else:
+            return self._locale['local_timezone'].localize(self.end)
 
 
 class AllDayEvent(Event):


### PR DESCRIPTION
I had two Errors occuring when importing one of my calenders:

 - TypeError: can't compare offset-naive and offset-aware datetimes
   (File "/usr/lib/python3.4/site-packages/khal/khalendar/aux.py", line 171, in sanitize_timerange)
This happened when a entry had start date with timezone, and end date without or vice versa (Those date where from a imported ical file)
I have not used python for a long time, and never used datetime. It works for me. But i guess the right thing to do would be to add the right timezone to the date without. I failed doing that, though :)

 - AttributeError: 'list' object has no attribute 'dt'
   (File "/usr/lib/python3.4/site-packages/khal/khalendar/aux.py", line 226, in invalid_timezone)
No idea where those came from. Anyway, i bet just returning false is only masking the real problem here.

I guess both problem correlate somehow. Maybe fixing the second one right will fix the first too :)

Here is one of the offending dates:
BEGIN:VCALENDAR
VERSION:2.0
PRODID:ownCloud Calendar 0.7.3
BEGIN:VEVENT
SUMMARY:Termin:Junghackertag
URL:http://wiki.hamburg.ccc.de/Termin:Junghackertag
UID:http://wiki.hamburg.ccc.de/Termin:Junghackertag
DTSTART:20150530T120000
DTEND;VALUE=:20150530T160000Z
DESCRIPTION:Junghackertag
DTSTAMP:20150526T182050
SEQUENCE:10172
END:VEVENT
END:VCALENDAR
