### PR TITLE
WIP: Allow configuring excluded calendars

### DIFF
--- a/doc/source/configspec.rst
+++ b/doc/source/configspec.rst
@@ -396,6 +396,17 @@ behaviours are set here.
       :type: boolean
       :default: False
 
+.. _default-exclude_calendars:
+
+.. object:: exclude_calendars
+
+    
+    A list of calendars that should be excluded by default when running `khal`.
+    These can be included again explicitly by using the `-a` flag.
+
+      :type: list
+      :default: 
+
 .. _default-default_calendar:
 
 .. object:: default_calendar

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -60,7 +60,7 @@ def _multi_calendar_select_callback(ctx, option, calendars):
     if not isinstance(calendars, tuple):
         calendars = (calendars,)
 
-    mode = option.name
+    mode = ctx.obj['calendar_selection_mode'] = option.name
     selection = ctx.obj['calendar_selection'] = set()
 
     if mode == 'include_calendar':
@@ -149,10 +149,17 @@ def build_collection(ctx):
     try:
         conf = ctx.obj['conf']
         selection = ctx.obj.get('calendar_selection', None)
+        mode = ctx.obj.get('calendar_selection_model')
+
+        if ctx.command.name != 'interactive':
+            exclude = ctx.obj['conf']['default']['exclude_calendars']
+        else:
+            exclude = []
 
         props = dict()
         for name, cal in conf['calendars'].items():
-            if selection is None or name in ctx.obj['calendar_selection']:
+            if (selection is None or name in selection) and \
+               (mode == 'include_calendar' or (name not in exclude)):
                 props[name] = {
                     'name': name,
                     'path': cal['path'],

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -174,6 +174,8 @@ print_new = option('event', 'path', 'False', default=False)
 # highlighting are in [highlight_days] section.
 highlight_event_days = boolean(default=False)
 
+# A list of calendars that should be excluded by default when running `khal`.
+# These can be included again explicitly by using the `-a` flag.
 exclude_calendars = force_list(default=list())
 
 # The view section contains config options that effect the visual appearance

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -174,6 +174,8 @@ print_new = option('event', 'path', 'False', default=False)
 # highlighting are in [highlight_days] section.
 highlight_event_days = boolean(default=False)
 
+exclude_calendars = force_list(default=list())
+
 # The view section contains config options that effect the visual appearance
 # when using ikhal
 [view]

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -43,7 +43,8 @@ class TestSettings(object):
                 'show_all_days': False,
                 'print_new': 'False',
                 'days': 2,
-                'highlight_event_days': False
+                'highlight_event_days': False,
+                'exclude_calendars': []
             }
         }
         for key in comp_config:
@@ -83,7 +84,8 @@ class TestSettings(object):
                 'print_new': 'False',
                 'show_all_days': False,
                 'days': 2,
-                'highlight_event_days': False
+                'highlight_event_days': False,
+                'exclude_calendars': []
             }
         }
         for key in comp_config:


### PR DESCRIPTION
Implement a configuration option [default][exclude_calendars] which allows excluding calendars from khal by default.

This is equivalent to always running khal with `d CALENDAR`, so this setting might be considered a default `-d` setting, that DOES NOT clash with `-a`.

I find this very useful for calendar which I want to track but don't want listed all the time (maybe due to lack of importance, or maybe because it has too many events).