### PR TITLE
Fix calendar selection when importing events

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -257,7 +257,7 @@ def import_event(vevent, collection, locale, batch, random_uid):
                 calendar_name = collection.writable_names[number]
                 break
             except (ValueError, IndexError):
-                matches = filter(lambda x: x.startswith(value), collection.writable_names)
+                matches = [x for x in collection.writable_names if x.startswith(value)]
                 if len(matches) == 1:
                     calendar_name = matches[0]
                     break


### PR DESCRIPTION
When importing an event, khal asks for the calendar into which the event is to be imported. If a calendar is selected by name, rather than by number, khal crashes with a `TypeError: 'filter' object is not subscriptable`. This happens, in particular, when the user does not enter anything at all in order to use the default calendar.

This PR fixes the issue by replacing the filter with a list comprehension. I'm not sure if this is the best possible fix, but it works and is fairly readable.