### PR TITLE
Fix building man pages

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -71,7 +71,7 @@ release = khal.__version__
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = ['man.rst', 'configspec.rst']
+exclude_patterns = ['configspec.rst']
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.


### PR DESCRIPTION
Commit 7edaf9604ff246b9d201b69ac7297e44606a5a0b broke the man page build. For some reason, man.rst was added to the list of excluded source files used for building the documentation. This reverts that change.