### PR TITLE
New widget FocusLineBox

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -27,7 +27,8 @@ import urwid
 
 from .. import aux
 from . import colors
-from .widgets import ExtendedEdit as Edit, NPile, NColumns, NListBox, Choice, AlarmsEditor
+from .widgets import ExtendedEdit as Edit, NPile, NColumns, NListBox, Choice, AlarmsEditor, \
+    FocusLineBox
 from .base import Pane, Window
 from .startendeditor import StartEndEditor
 from .calendarwidget import CalendarWidget
@@ -357,7 +358,7 @@ class EventColumn(urwid.WidgetWrap):
         current_day = self.container.contents[0][0]
 
         if self.pane.conf['view']['frame']:
-            ContainerWidget = urwid.LineBox
+            ContainerWidget = FocusLineBox
         else:
             ContainerWidget = urwid.WidgetPlaceholder
         new_pane = urwid.Columns([
@@ -737,7 +738,7 @@ class ClassicView(Pane):
         self.collection = collection
         self.deleted = {ALL: [], INSTANCES: []}
 
-        ContainerWidget = urwid.LineBox if self.conf['view']['frame'] else urwid.WidgetPlaceholder
+        ContainerWidget = FocusLineBox if self.conf['view']['frame'] else urwid.WidgetPlaceholder
         self.eventscolumn = ContainerWidget(EventColumn(pane=self))
         calendar = CalendarWidget(
             on_date_change=self.show_date,

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -548,3 +548,50 @@ class AlarmsEditor(urwid.WidgetWrap):
             return self.event.alarms != self.get_alarms()
         except ValueError:
             return False
+
+
+class FocusLineBox(urwid.WidgetDecoration, urwid.WidgetWrap):
+    def __init__(self, widget):
+        hline = urwid.Divider('─')
+        hline_focus = urwid.Divider('═')
+        self._vline = urwid.SolidFill('│')
+        self._vline_focus = urwid.SolidFill('║')
+        self._topline = urwid.Columns([
+            ('fixed', 1, urwid.Text('┌')),
+            hline,
+            ('fixed', 1, urwid.Text('┐')),
+        ])
+        self._topline_focus = urwid.Columns([
+            ('fixed', 1, urwid.Text('╔')),
+            hline_focus,
+            ('fixed', 1, urwid.Text('╗')),
+        ])
+        self._bottomline = urwid.Columns([
+            ('fixed', 1, urwid.Text('└')),
+            hline,
+            ('fixed', 1, urwid.Text('┘')),
+        ])
+        self._bottomline_focus = urwid.Columns([
+            ('fixed', 1, urwid.Text('╚')),
+            hline_focus,
+            ('fixed', 1, urwid.Text('╝')),
+        ])
+        self._middle = urwid.Columns([('fixed', 1, self._vline), widget, ('fixed', 1, self._vline)])
+        self._all = urwid.Pile([('flow', self._topline), self._middle, ('flow', self._bottomline)])
+
+        urwid.WidgetDecoration.__init__(self, widget)
+        urwid.WidgetWrap.__init__(self, self._all)
+
+    def render(self, size, focus):
+        inner = self._all.contents[1][0]
+        if focus:
+            self._all.contents[0] = (self._topline_focus, ('pack', None))
+            inner.contents[0] = (self._vline_focus, ('given', 1, False))
+            inner.contents[2] = (self._vline_focus, ('given', 1, False))
+            self._all.contents[2] = (self._bottomline_focus, ('pack', None))
+        else:
+            self._all.contents[0] = (self._topline, ('pack', None))
+            inner.contents[0] = (self._vline, ('given', 1, False))
+            inner.contents[2] = (self._vline, ('given', 1, False))
+            self._all.contents[2] = (self._bottomline, ('pack', None))
+        return super().render(size, focus)


### PR DESCRIPTION
This new widget will change its border if in focus or not. There are currently two alternatives, one where the focused widget has a double lined border and one with a thick border. Which one do you like better? (see `FocusLineWidget_thick` for the other version).
![2016-05-05-010636_652x530_scrot](https://cloud.githubusercontent.com/assets/275330/15032074/03dfd47c-125e-11e6-8a08-c770bf9cecf4.png)
![2016-05-05-010714_652x530_scrot](https://cloud.githubusercontent.com/assets/275330/15032081/0662dee2-125e-11e6-854b-d9b1170cb805.png)

**Edit:** Obviously the exact layout will depend on your font, terminal color scheme etc.

