### PR TITLE
Use event.format for search (and sort search)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ not released yet
   locale should now be figured out automatically (Markus Unterwaditzer)
 * added command `list`
 * support for categories (and add `-g` flag for `khal new`) (Pierre David)
+* search is now sorted and allows for a `--format` (Taylor Money)
 
 0.8.1
 =====

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -23,6 +23,7 @@ import logging
 import sys
 import textwrap
 from shutil import get_terminal_size
+import datetime
 
 try:
     from setproctitle import setproctitle
@@ -455,20 +456,25 @@ def _get_cli():
 
     @cli.command()
     @multi_calendar_option
+    @click.option('--format', '-f',
+                  help=('The format of the events.'))
     @click.argument('search_string')
     @click.pass_context
-    def search(ctx, search_string):
+    def search(ctx, format,  search_string):
         '''Search for events matching SEARCH_STRING.
 
         For repetitive events only one event is currently shown.
         '''
         # TODO support for time ranges, location, description etc
+        if format is None:
+            format = ctx.obj['conf']['view']['event_format']
         collection = build_collection(ctx)
         events = sorted(collection.search(search_string))
         event_column = list()
         term_width, _ = get_terminal_size()
+        now = datetime.datetime.now()
         for event in events:
-            desc = textwrap.wrap(event.event_description, term_width)
+            desc = textwrap.wrap(event.format(format, relative_to=now), term_width)
             event_column.extend(
                 [colored(d, event.color,
                          bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color'])

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -464,7 +464,7 @@ def _get_cli():
         '''
         # TODO support for time ranges, location, description etc
         collection = build_collection(ctx)
-        events = collection.search(search_string)
+        events = sorted(collection.search(search_string))
         event_column = list()
         term_width, _ = get_terminal_size()
         for event in events:

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -303,8 +303,9 @@ def test_search(runner):
     runner = runner(command='calendar', showalldays=False, days=2)
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     result = runner.invoke(main_khal, 'new {} 18:00 myevent'.format(now).split())
-    result = runner.invoke(main_khal, ['--color', 'search', 'myevent'])
-    assert result.output.startswith('\x1b[34m18:00')
+    format = '{red}{start-end-time-style}{reset} {title} :: {description}'
+    result = runner.invoke(main_khal, ['--color', 'search', '--format', format, 'myevent'])
+    assert result.output.startswith('\x1b[34m\x1b[31m18:00')
     assert not result.exception
 
 


### PR DESCRIPTION
fixes #397 by adding sorting, and moves in the direction of adding event.format to all commands