### PR TITLE
Use format and list for at command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,10 @@ not released yet
 * `calendar` command uses `list` (Taylor Money)
 * `new` prints using event.format (Taylor Money)
 * remove `agenda` in favor of list (Taylor Money)
+* removed `days` configuration option in favor of `timedelta` (Taylor Money)
+* added `event_format`, `agenda_event_format`, `agenda_day_format` config
+  options for formatting (Taylor Money)
+
 
 ikhal
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ not released yet
 * `at` command now works like list with end of `0m` (Taylor Money)
 * `calendar` command uses `list` (Taylor Money)
 * `new` prints using event.format (Taylor Money)
+* remove `agenda` in favor of list (Taylor Money)
 
 ikhal
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ not released yet
 * support for categories (and add `-g` flag for `khal new`) (Pierre David)
 * search is now sorted and allows for a `--format` (Taylor Money)
 * calendar path is now a glob without recursion for discover (Taylor Money)
+* `at` command now works like list with end of `0m` (Taylor Money)
 
 ikhal
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ not released yet
 * calendar path is now a glob without recursion for discover (Taylor Money)
 * `at` command now works like list with end of `0m` (Taylor Money)
 * `calendar` command uses `list` (Taylor Money)
+* `new` prints using event.format (Taylor Money)
 
 ikhal
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ not released yet
 * search is now sorted and allows for a `--format` (Taylor Money)
 * calendar path is now a glob without recursion for discover (Taylor Money)
 * `at` command now works like list with end of `0m` (Taylor Money)
+* `calendar` command uses `list` (Taylor Money)
 
 ikhal
 -----

--- a/doc/source/configspec.rst
+++ b/doc/source/configspec.rst
@@ -525,10 +525,33 @@ when using ikhal
 .. object:: event_format
 
     
-    Default format for events (used in list)
+    Default format for events (used when not showing an agenda)
 
       :type: string
-      :default: {start}-{end} {title}
+      :default: {calendar-color}{start}-{end}
+      {title}{recurse}{description-seperator}{description}{reset}
+
+.. _view-agenda_event_format:
+
+.. object:: agenda_event_format
+
+    
+    Default format for events (used in list and calendar)
+
+      :type: string
+      :default: {calendar-color}{start-end-time-style:16}
+      {title}{recurse}{description-seperator}{description}{reset}
+
+
+.. _view-_format:
+
+.. object:: agenda_day_format
+
+    
+    Default format for day headers (used in list and calendar)
+
+      :type: string
+      :default: {name}
 
 .. _view-event_view_always_visible:
 

--- a/doc/source/configspec.rst
+++ b/doc/source/configspec.rst
@@ -87,18 +87,6 @@ The [default] section
 The default section begins with a **[default]** tag. Some default values and
 behaviours are set here.
 
-.. _default-days:
-
-.. object:: days
-
-    
-    By default, khal shows events for today and tomorrow.
-    Setting this to a different value will show events of that amount of days by
-    default.
-
-      :type: integer
-      :default: 2
-
 .. _default-default_calendar:
 
 .. object:: default_calendar
@@ -117,7 +105,7 @@ behaviours are set here.
     
     command to be executed if no command is given when executing khal
 
-      :type: option, allowed values are *calendar*, *agenda*, *interactive*, *printformats*, *printcalendars* and **
+      :type: option, allowed values are *calendar*, *list*, *interactive*, *printformats*, *printcalendars* and **
       :default: calendar
 
 .. _default-highlight_event_days:
@@ -142,18 +130,6 @@ behaviours are set here.
       :type: option, allowed values are *event*, *path* and *False*
       :default: False
 
-.. _default-show_all_days:
-
-.. object:: show_all_days
-
-    
-    By default, khal displays only dates with event in "agenda" view.
-    Setting this to *True* will show all days in "agenda", even
-    when there is no event scheduled on that day.
-
-      :type: boolean
-      :default: False
-
 .. _default-timedelta:
 
 .. object:: timedelta
@@ -162,7 +138,7 @@ behaviours are set here.
     Default timedelta for use with daterange options
 
       :type: string
-      :default: 
+      :default: 2d
 
 The [highlight_days] section
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -509,6 +485,25 @@ The [view] section
 The view section contains configuration options that effect the visual appearance
 when using ikhal
 
+.. _view-agenda_day_format:
+
+.. object:: agenda_day_format
+
+    
+
+      :type: string
+      :default: {bold}{name}{reset}
+
+.. _view-agenda_event_format:
+
+.. object:: agenda_event_format
+
+    
+    Default format for events (used in list)
+
+      :type: string
+      :default: {calendar-color}{start-end-time-style:16} {title}{recurse}{description-separator}{description}{reset}
+
 .. _view-bold_for_light_color:
 
 .. object:: bold_for_light_color
@@ -525,33 +520,9 @@ when using ikhal
 .. object:: event_format
 
     
-    Default format for events (used when not showing an agenda)
 
       :type: string
-      :default: {calendar-color}{start}-{end}
-      {title}{recurse}{description-seperator}{description}{reset}
-
-.. _view-agenda_event_format:
-
-.. object:: agenda_event_format
-
-    
-    Default format for events (used in list and calendar)
-
-      :type: string
-      :default: {calendar-color}{start-end-time-style:16}
-      {title}{recurse}{description-seperator}{description}{reset}
-
-
-.. _view-_format:
-
-.. object:: agenda_day_format
-
-    
-    Default format for day headers (used in list and calendar)
-
-      :type: string
-      :default: {name}
+      :default: {calendar-color}{start}-{end} {title}{recurse}{description-separator}{description}{reset}
 
 .. _view-event_view_always_visible:
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -230,17 +230,18 @@ start.
 
 calendar
 ********
-shows a calendar (similar to :manpage:`cal(1)`) and agenda. ``khal calendar``
+shows a calendar (similar to :manpage:`cal(1)`) and list. ``khal calendar``
 should understand the following syntax:
 
 ::
 
-        khal calendar [-a CALENDAR ... | -d CALENDAR ...] [--days N] [DATE ...]
+        khal calendar [-a CALENDAR ... | -d CALENDAR ...] [START DATETIME]
+        [END DATETIME]
 
-Date selection works exactly as for ``khal agenda``. The displayed calendar
+Date selection works exactly as for ``khal list``. The displayed calendar
 contains three consecutive months, where the first month is the month
 containing the first given date. If today is included, it is highlighted.
-Have a look at ``khal agenda`` for a description of the options.
+Have a look at ``khal list`` for a description of the options.
 
 configure
 *********

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -69,7 +69,7 @@ formatting
 
 ::
         khal list [-a CALENDAR ... | -d CALENDAR ...] [--format FORMAT]
-        [--once] [--notstarted] [START [END | DELTA] ]
+        [--day-format DAYFORMAT] [--once] [--notstarted] [START [END | DELTA] ]
 
 START and END can both be given as dates, datetimes or times (it is assumed
 today is meant in the case of only a given time) in the formats configured in
@@ -179,19 +179,6 @@ the terminal.  The available template options are:
         A concatenation of start-style, to-style, and end-style OR an
         appropriate symbol.
 
-.. option:: start-date-once
-
-        The start date, so long as that date has not yet been printed.
-
-.. option:: start-dayname-once
-
-        The start dayname, so long as that date has not yet been printed. eg
-        Tomorrow, or Wednesday.
-
-.. option:: start-date-once-newline
-
-        A newline if start-date-once is not "".
-
 By default all-day events have no times. To see a start and end time anyway simply
 add `-full` to the end of any template with start/end, for instance
 `start-time` becomes `start-time-full` and will always show start and end times (instead
@@ -207,6 +194,22 @@ For example the below command with print the title and description of all events
 ::
 
         khal list --format "{title} {description}"
+
+For the day headings, `DAYFORMAT` is similar to event formatting but has only a
+small number of options (in addition to all of the color options).
+
+.. option:: date
+
+        The date in dateformat.
+
+.. option:: date-long
+
+        The date in longdateformat.
+
+.. option:: name
+
+        The date as a name.
+
 
 at
 **

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -95,7 +95,8 @@ assumed. Today is used for START if it is not explicitly given.  If DELTA, a
 (date)time range in the format `I{m,h,d}`, where `I` is an integer and `m` means
 minutes, `h` means hours, and `d` means days, is given, END is assumed to be
 START + DELTA.  A value of `eod` is also accepted as DELTA and means the end of
-day of the start date.
+day of the start date. In addition the DELTA `week` may be used to specify that
+the daterange should actually be the week containing the start date.
 
 The `--once` option only allows events to appear once even if they are on
 multiple days. With the `--notstarted` option only events are shown that start

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -1,6 +1,6 @@
 Usage
 =====
-Khal offers a set of commands, most importantly :command:`agenda`,
+Khal offers a set of commands, most importantly :command:`list`,
 :command:`calendar`, :command:`interactive`, :command:`new`,
 :command:`printcalendars`, :command:`printformats`, and :command:`search`. See
 below for a description of what every command does. Calling :program:`khal`
@@ -61,23 +61,6 @@ interpreted as that date *next* week (i.e. seven days from now).
 
 Commands
 --------
-
-agenda
-******
-shows all events scheduled for given dates. ``khal agenda`` should understand
-the following syntax:
-
-::
-
-    khal agenda [-a CALENDAR ... | -d CALENDAR ...] [--days N] [DATE ...]
-
-If no dates are supplied as arguments, today and tomorrow are used. Dates must
-be given in the format specified in khal's config file as *dateformat* or
-*longdateformat*. If *dateformat* is used, the current year is implied.
-
-.. option:: --days N
-
-        Specify how many days' (following each DATE) events should be shown.
 
 list
 ****

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -145,9 +145,9 @@ the terminal.  The available template options are:
 
         The event description.
 
-.. option:: description-seperator
+.. option:: description-separator
 
-        A seperator: " :: " that appears when there is a description.
+        A separator: " :: " that appears when there is a description.
 
 .. option:: location
 

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -79,16 +79,6 @@ be given in the format specified in khal's config file as *dateformat* or
 
         Specify how many days' (following each DATE) events should be shown.
 
-at
-**
-shows all events scheduled for a given datetime. ``khal at`` should be supplied
-with a date and time, a time (the date is then assumed to be today) or the
-string *now*. ``at`` defaults to *now*.
-
-::
-
-        khal at [-a CALENDAR ... | -d CALENDAR ...] [DATETIME | now]
-
 list
 ****
 shows all events scheduled for a given date (or datetime) range, with custom
@@ -223,6 +213,19 @@ For example the below command with print the title and description of all events
 ::
 
         khal list --format "{title} {description}"
+
+at
+**
+shows all events scheduled for a given datetime. ``khal at`` should be supplied
+with a date and time, a time (the date is then assumed to be today) or the
+string *now*. ``at`` defaults to *now*. The ``at`` command works just like the
+``list`` command, except it has an implicit end time of zero minutes after the
+start.
+
+::
+
+        khal list [-a CALENDAR ... | -d CALENDAR ...] [--format FORMAT]
+        [--notstarted] [START DATE]
 
 calendar
 ********

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -96,7 +96,7 @@ assumed. Today is used for START if it is not explicitly given.  If DELTA, a
 minutes, `h` means hours, and `d` means days, is given, END is assumed to be
 START + DELTA.  A value of `eod` is also accepted as DELTA and means the end of
 day of the start date. In addition the DELTA `week` may be used to specify that
-the daterange should actually be the week containing the start date.
+the daterange should actually be the week containing the START.
 
 The `--once` option only allows events to appear once even if they are on
 multiple days. With the `--notstarted` option only events are shown that start

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -162,6 +162,10 @@ the terminal.  The available template options are:
 
         The event description.
 
+.. option:: description-seperator
+
+        A seperator: " :: " that appears when there is a description.
+
 .. option:: location
 
         The event location.
@@ -196,6 +200,11 @@ the terminal.  The available template options are:
 
         The start date, so long as that date has not yet been printed.
 
+.. option:: start-dayname-once
+
+        The start dayname, so long as that date has not yet been printed. eg
+        Tomorrow, or Wednesday.
+
 .. option:: start-date-once-newline
 
         A newline if start-date-once is not "".
@@ -207,7 +216,8 @@ of being empty for all-day events).
 
 In addition there are colors: `black`, `red`, `green`, `yellow`, `blue`,
 `magenta`, `cyan`, `white` (and their bold versions: `red-bold`, etc.). There
-is also `reset`, which clears the styling.
+is also `reset`, which clears the styling, and `bold`, which is the normal
+bold.
 
 For example the below command with print the title and description of all events today.
 

--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -26,7 +26,5 @@ firstweekday = 0
 [default]
 default_command = calendar
 default_calendar = home
-# in agenda/calendar display, shows all days even if there is no event
-show_all_days = False
-days = 30  # the default is 2
+timedelta = 2 # the default timedelta that list uses
 highlight_event_days = True  # the default is False

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -106,7 +106,7 @@ def calc_day(dayname):
     :returns: date
     :rtype: datetime.datetime
     """
-    today = datetime.today()
+    today = datetime.combine(date.today(), time.min)
     dayname = dayname.lower()
     if dayname == 'today':
         return today
@@ -169,6 +169,12 @@ def guessdatetimefstr(dtime_list, locale, default_day=None):
             a_date = datetime(*(default_day.timetuple()[:3] + a_date.timetuple()[3:5]))
         return a_date
 
+    def datetimefwords(dtime_list, _):
+        if len(dtime_list) > 0 and dtime_list[0].lower() == 'now':
+            dtime_list.pop(0)
+            return datetime.now()
+        raise ValueError
+
     def datefstr_year(dtime_list, dateformat):
         """should be used if a date(time) without year is given
 
@@ -201,6 +207,7 @@ def guessdatetimefstr(dtime_list, locale, default_day=None):
             (datefstr_year, locale['dateformat'], True),
             (datetimefstr, locale['longdateformat'], True),
             (datefstr_weekday, None, True),
+            (datetimefwords, None, False),
 
     ]:
         try:

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -255,7 +255,7 @@ def guesstimedeltafstr(delta_string):
     return res
 
 
-def guessrangefstr(daterange, locale, default_timedelta=None):
+def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
     """parses a range string
 
     :param daterange: date1 [date2 | timedelta]
@@ -284,12 +284,20 @@ def guessrangefstr(daterange, locale, default_timedelta=None):
             if start is None:
                 start = datetime_fillin(end=False)
             elif not isinstance(start, date):
-                split = start.split(" ")
-                start = guessdatetimefstr(split, locale)[0]
-                if len(split) != 0:
-                    continue
+                if start.lower() == 'week':
+                    today_weekday = datetime.today().weekday()
+                    start = datetime.today() - timedelta(days=(today_weekday - first_weekday))
+                    end = start + timedelta(days=7)
+                else:
+                    split = start.split(" ")
+                    start = guessdatetimefstr(split, locale)[0]
+                    if len(split) != 0:
+                        continue
 
-            if end is None or len(end) == 0:
+            if isinstance(end, datetime):
+                pass
+
+            elif end is None or len(end) == 0:
                 if default_timedelta is not None:
                     end = start + default_timedelta
                 else:
@@ -297,6 +305,9 @@ def guessrangefstr(daterange, locale, default_timedelta=None):
             else:
                 if end.lower() == 'eod':
                     end = datetime_fillin(day=start)
+                elif end.lower() == 'week':
+                    start -= timedelta(days=(start.weekday() - first_weekday))
+                    end = start + timedelta(days=7)
                 else:
                     try:
                         delta = guesstimedeltafstr(end)

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -270,7 +270,7 @@ def guessrangefstr(daterange, locale, default_timedelta=None):
         range_list = daterange.split()
 
     try:
-        if len(default_timedelta) == 0:
+        if default_timedelta is None or len(default_timedelta) == 0:
             default_timedelta = None
         else:
             default_timedelta = guesstimedeltafstr(default_timedelta)
@@ -308,7 +308,7 @@ def guessrangefstr(daterange, locale, default_timedelta=None):
                             continue
                     end = datetime_fillin(end)
             return start, end
-        except Exception:   # XXX FIXME what kind of exceptions do we want to catch here?
+        except ValueError:
             pass
 
     return None, None
@@ -347,7 +347,7 @@ def datetime_fillin(dt=None, end=True, locale=None, day=None):
     if locale is not None:
         try:
             dt = locale['local_timezone'].localize(dt)
-        except:
+        except ValueError:
             pass
 
     return dt

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -98,6 +98,25 @@ def weekdaypstr(dayname):
     raise ValueError('invalid weekday name `%s`' % dayname)
 
 
+def construct_daynames(daylist):
+    """returns a list of tuples of datetime objects and datenames
+
+    :param daylist: list of dates
+    :type daylist: list(datetime.date)
+    :param longdateformat: format in which to print dates
+    :param str
+    :returns: list of names and dates
+    :rtype: list((str, datetime.date))
+    """
+    for day in daylist:
+        if day == date.today():
+            yield (day, 'Today:')
+        elif day == date.today() + timedelta(days=1):
+            yield (day, 'Tomorrow:')
+        else:
+            yield (day, day.strftime('%A'))
+
+
 def calc_day(dayname):
     """converts a relative date's description to a datetime object
 

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -341,6 +341,8 @@ def _get_cli():
                   help=('Stop an event repeating on this date.'))
     @click.option('--alarm', '-m',
                   help=('Alarm time for the new event.'))
+    @click.option('--format', '-f',
+                  help=('The format to print the event.'))
     @click.argument('START', nargs=1, required=True)
     @click.argument('END', nargs=1, required=False)
     @click.argument('TIMEZONE', nargs=1, required=False)
@@ -348,7 +350,7 @@ def _get_cli():
     @click.argument('DESCRIPTION', metavar='[:: DESCRIPTION]', nargs=-1, required=False)
     @click.pass_context
     def new(ctx, calendar, start, end, timezone, summary, description, location, categories, repeat,
-            until, alarm):
+            until, alarm, format):
         '''Create a new event from arguments.
 
         START and END can be either dates, times or datetimes, please have a

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -283,6 +283,7 @@ def _get_cli():
             color=ctx.obj['conf']['highlight_days']['color'],
             highlight_event_days=ctx.obj['conf']['default']['highlight_event_days'],
             bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color'],
+            env={"calendars": ctx.obj['conf']['calendars']}
         )
 
     @cli.command("list")
@@ -362,6 +363,7 @@ def _get_cli():
             repeat=repeat,
             until=until.split(' ') if until is not None else None,
             alarm=alarm,
+            env={"calendars": ctx.obj['conf']['calendars']}
         )
 
     @cli.command('import')
@@ -400,7 +402,8 @@ def _get_cli():
             ctx.obj['conf'],
             ics=ics_str,
             batch=batch,
-            random_uid=random_uid
+            random_uid=random_uid,
+            env={"calendars": ctx.obj['conf']['calendars']}
         )
 
     @cli.command()
@@ -470,8 +473,9 @@ def _get_cli():
         event_column = list()
         term_width, _ = get_terminal_size()
         now = datetime.datetime.now()
+        env = {"calendars": ctx.obj['conf']['calendars']}
         for event in events:
-            desc = textwrap.wrap(event.format(format, relative_to=now), term_width)
+            desc = textwrap.wrap(event.format(format, relative_to=now, env=env), term_width)
             event_column.extend(
                 [colored(d, event.color,
                          bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color'])
@@ -497,7 +501,7 @@ def _get_cli():
             build_collection(ctx),
             format=format,
             day_format=day_format,
-            daterange=datetime + ("0m", ),
+            daterange=datetime + ("1m", ),
             once=True,
             notstarted=notstarted,
             locale=ctx.obj['conf']['locale'],

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -389,8 +389,10 @@ def _get_cli():
     @click.option('--random_uid', '-r', help=('Select a random uid.'),
                   is_flag=True)
     @click.argument('ics', type=click.File('rb'))
+    @click.option('--format', '-f',
+                  help=('The format to print the event.'))
     @click.pass_context
-    def import_ics(ctx, ics, include_calendar, batch, random_uid):
+    def import_ics(ctx, ics, include_calendar, batch, random_uid, format):
         '''Import events from an .ics file.
 
         If an event with the same UID is already present in the (implicitly)

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -256,17 +256,20 @@ def _get_cli():
     @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
+    @click.option('--day-format', '-df',
+                  help=('The format of the day line.'))
     @click.option('--once', '-o', help=('Print event only once'),
                   is_flag=True)
     @click.option('--notstarted', help=('Print only events that have not started'),
                   is_flag=True)
     @click.argument('DATERANGE', nargs=-1, required=False)
     @click.pass_context
-    def calendar(ctx, daterange, once, notstarted, format):
+    def calendar(ctx, daterange, once, notstarted, format, day_format):
         '''Print calendar with agenda.'''
         controllers.calendar(
             build_collection(ctx),
             format=format,
+            day_format=day_format,
             once=once,
             notstarted=notstarted,
             daterange=daterange,
@@ -286,6 +289,8 @@ def _get_cli():
     @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
+    @click.option('--day-format', '-df',
+                  help=('The format of the day line.'))
     @click.option(
         '--once', '-o', is_flag=True,
         help='Print events only once, even if they span multiple days')
@@ -293,11 +298,12 @@ def _get_cli():
                   is_flag=True)
     @click.argument('DATERANGE', nargs=-1, required=False)
     @click.pass_context
-    def klist(ctx, daterange, once, notstarted, format):
+    def klist(ctx, daterange, once, notstarted, format, day_format):
         '''Print list.'''
         controllers.khal_list(
             build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
             format=format,
+            day_format=day_format,
             daterange=daterange,
             once=once,
             notstarted=notstarted,
@@ -477,17 +483,20 @@ def _get_cli():
     @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
+    @click.option('--day-format', '-df',
+                  help=('The format of the day line.'))
     @click.option('--notstarted', help=('Print only events that have not started'),
                   is_flag=True)
     @click.argument('DATETIME', nargs=-1, required=False)
     @click.pass_context
-    def at(ctx, datetime, notstarted, format):
+    def at(ctx, datetime, notstarted, format, day_format):
         '''Print list.'''
         if not datetime:
             datetime = ("now",)
         controllers.khal_list(
             build_collection(ctx),
             format=format,
+            day_format=day_format,
             daterange=datetime + ("0m", ),
             once=True,
             notstarted=notstarted,

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -253,32 +253,33 @@ def _get_cli():
                 ctx.exit(1)
 
     @cli.command()
-    @time_args
     @multi_calendar_option
-    @click.pass_context
-    @click.option('--full', '-f', help=('Print description and location with event'),
+    @click.option('--format', '-f',
+                  help=('The format of the events.'))
+    @click.option('--once', '-o', help=('Print event only once'),
                   is_flag=True)
-    def calendar(ctx, days, events, dates, week, full=False):
+    @click.option('--notstarted', help=('Print only events that have not started'),
+                  is_flag=True)
+    @click.argument('DATERANGE', nargs=-1, required=False)
+    @click.pass_context
+    def calendar(ctx, daterange, once, notstarted, format):
         '''Print calendar with agenda.'''
-        if week and days:
-            raise click.UsageError('Cannot use --days and -week at the same time.')
         controllers.calendar(
-            build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
-            dates=dates,
+            build_collection(ctx),
+            format=format,
+            once=once,
+            notstarted=notstarted,
+            daterange=daterange,
+            conf=ctx.obj['conf'],
             firstweekday=ctx.obj['conf']['locale']['firstweekday'],
             locale=ctx.obj['conf']['locale'],
             weeknumber=ctx.obj['conf']['locale']['weeknumbers'],
-            show_all_days=ctx.obj['conf']['default']['show_all_days'],
-            days=days or ctx.obj['conf']['default']['days'],
-            events=events,
             hmethod=ctx.obj['conf']['highlight_days']['method'],
             default_color=ctx.obj['conf']['highlight_days']['default_color'],
             multiple=ctx.obj['conf']['highlight_days']['multiple'],
             color=ctx.obj['conf']['highlight_days']['color'],
             highlight_event_days=ctx.obj['conf']['default']['highlight_event_days'],
             bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color'],
-            full=full,
-            week=week,
         )
 
     @cli.command()

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -282,29 +282,6 @@ def _get_cli():
             bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color'],
         )
 
-    @cli.command()
-    @time_args
-    @multi_calendar_option
-    @click.pass_context
-    @click.option('--full', '-f', help=('Print description and location with event'),
-                  is_flag=True)
-    def agenda(ctx, days, events, dates, week, full=False):
-        '''Print agenda.'''
-        if week and days:
-            raise click.UsageError('Cannot use --days and -week at the same time.')
-        controllers.agenda(
-            build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
-            dates=dates,
-            firstweekday=ctx.obj['conf']['locale']['firstweekday'],
-            show_all_days=ctx.obj['conf']['default']['show_all_days'],
-            locale=ctx.obj['conf']['locale'],
-            days=days or ctx.obj['conf']['default']['days'],
-            events=events,
-            week=week,
-            full=full,
-            bold_for_light_color=ctx.obj['conf']['view']['bold_for_light_color']
-        )
-
     @cli.command("list")
     @multi_calendar_option
     @click.option('--format', '-f',

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -267,7 +267,7 @@ def _get_cli():
     def calendar(ctx, daterange, once, notstarted, format, day_format):
         '''Print calendar with agenda.'''
         controllers.calendar(
-            build_collection(ctx),
+            build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
             format=format,
             day_format=day_format,
             once=once,
@@ -498,7 +498,7 @@ def _get_cli():
         if not datetime:
             datetime = ("now",)
         controllers.khal_list(
-            build_collection(ctx),
+            build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
             format=format,
             day_format=day_format,
             daterange=datetime + ("1m", ),

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -27,7 +27,7 @@ from vdirsyncer.utils.vobject import Item
 from collections import defaultdict
 from shutil import get_terminal_size
 
-from datetime import date, timedelta
+from datetime import date, timedelta, datetime
 import logging
 import sys
 import textwrap
@@ -315,7 +315,8 @@ def khal_list(collection, daterange, conf=None, format=None, once=False,
 
 
 def new_from_string(collection, calendar_name, conf, date_list, location=None,
-                    categories=None, repeat=None, until=None, alarm=None):
+                    categories=None, repeat=None, until=None, alarm=None,
+                    format=None):
     """construct a new event from a string and add it"""
     try:
         event = aux.construct_event(
@@ -338,7 +339,9 @@ def new_from_string(collection, calendar_name, conf, date_list, location=None,
                      'read-only'.format(calendar_name))
         sys.exit(1)
     if conf['default']['print_new'] == 'event':
-        echo(event.event_description)
+        if format is None:
+            format = conf['view']['event_format']
+        echo(event.format(format, datetime.now()))
     elif conf['default']['print_new'] == 'path':
         path = collection._calnames[event.calendar].path + event.href
         echo(path)

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -362,7 +362,7 @@ def interactive(collection, conf):
     )
 
 
-def import_ics(collection, conf, ics, batch=False, random_uid=False):
+def import_ics(collection, conf, ics, batch=False, random_uid=False, format=None):
     """
     :param batch: setting this to True will insert without asking for approval,
                   even when an event with the same uid already exists
@@ -374,14 +374,17 @@ def import_ics(collection, conf, ics, batch=False, random_uid=False):
     for event in events:
         events_grouped[event['UID']].append(event)
 
+    if format is None:
+        format = conf['view']['event_format']
+
     vevents = list()
     for uid in events_grouped:
         vevents.append(sorted(events_grouped[uid], key=sort_key))
     for vevent in vevents:
-        import_event(vevent, collection, conf['locale'], batch, random_uid)
+        import_event(vevent, collection, conf['locale'], batch, random_uid, format)
 
 
-def import_event(vevent, collection, locale, batch, random_uid):
+def import_event(vevent, collection, locale, batch, random_uid, format=None):
     """import one event into collection, let user choose the collection"""
 
     # print all sub-events
@@ -389,7 +392,7 @@ def import_event(vevent, collection, locale, batch, random_uid):
         if not batch:
             event = Event.fromVEvents(
                 [sub_event], calendar=collection.default_calendar_name, locale=locale)
-            echo(event.event_description)
+            echo(event.format(format, datetime.now()))
 
     # get the calendar to insert into
     if batch or len(collection.writable_names) == 1:

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -200,7 +200,15 @@ def get_list_from_str(collection, locale, daterange, notstarted=False,
     """
     if len(daterange) == 0:
         start = aux.datetime_fillin(end=False)
-        end = aux.datetime_fillin(day=start)
+        if default_timedelta is None:
+            end = aux.datetime_fillin(day=start)
+        else:
+            try:
+                end = start + aux.guesstimedeltafstr(default_timedelta)
+            except ValueError as e:
+                logging.fatal(e)
+                sys.exit(1)
+
     else:
         try:
             start, end = aux.guessrangefstr(

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -269,7 +269,7 @@ def khal_list(collection, daterange, conf=None, format=None, day_format=None,
 
 def new_from_string(collection, calendar_name, conf, date_list, location=None,
                     categories=None, repeat=None, until=None, alarm=None,
-                    format=None):
+                    format=None, env=None):
     """construct a new event from a string and add it"""
     try:
         event = aux.construct_event(
@@ -294,7 +294,7 @@ def new_from_string(collection, calendar_name, conf, date_list, location=None,
     if conf['default']['print_new'] == 'event':
         if format is None:
             format = conf['view']['event_format']
-        echo(event.format(format, datetime.now()))
+        echo(event.format(format, datetime.now(), env=env))
     elif conf['default']['print_new'] == 'path':
         path = collection._calnames[event.calendar].path + event.href
         echo(path)
@@ -315,7 +315,8 @@ def interactive(collection, conf):
     )
 
 
-def import_ics(collection, conf, ics, batch=False, random_uid=False, format=None):
+def import_ics(collection, conf, ics, batch=False, random_uid=False, format=None,
+               env=None):
     """
     :param batch: setting this to True will insert without asking for approval,
                   even when an event with the same uid already exists
@@ -334,10 +335,10 @@ def import_ics(collection, conf, ics, batch=False, random_uid=False, format=None
     for uid in events_grouped:
         vevents.append(sorted(events_grouped[uid], key=sort_key))
     for vevent in vevents:
-        import_event(vevent, collection, conf['locale'], batch, random_uid, format)
+        import_event(vevent, collection, conf['locale'], batch, random_uid, format, env)
 
 
-def import_event(vevent, collection, locale, batch, random_uid, format=None):
+def import_event(vevent, collection, locale, batch, random_uid, format=None, env=None):
     """import one event into collection, let user choose the collection"""
 
     # print all sub-events
@@ -345,7 +346,7 @@ def import_event(vevent, collection, locale, batch, random_uid, format=None):
         if not batch:
             event = Event.fromVEvents(
                 [sub_event], calendar=collection.default_calendar_name, locale=locale)
-            echo(event.format(format, datetime.now()))
+            echo(event.format(format, datetime.now(), env=env))
 
     # get the calendar to insert into
     if batch or len(collection.writable_names) == 1:

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -78,7 +78,7 @@ def calendar(collection, format=None, notstarted=False, once=False, daterange=No
     td = None
     if conf is not None:
         if format is None:
-            format = conf['view']['event_format']
+            format = conf['view']['agenda_event_format']
         td = conf['default']['timedelta']
 
     term_width, _ = get_terminal_size()
@@ -226,7 +226,7 @@ def khal_list(collection, daterange, conf=None, format=None, once=False,
     td = None
     if conf is not None:
         if format is None:
-            format = conf['view']['event_format']
+            format = conf['view']['agenda_event_format']
         td = conf['default']['timedelta']
 
     event_column = get_list_from_str(

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -97,12 +97,14 @@ def calendar(collection, format=None, notstarted=False, once=False, daterange=No
              bold_for_light_color=True,
              **kwargs):
     td = None
+    show_all_days = False
     if conf is not None:
         if format is None:
             format = conf['view']['agenda_event_format']
         if day_format is None:
             day_format = conf['view']['agenda_day_format']
         td = conf['default']['timedelta']
+        show_all_days = conf['default']['show_all_days']
 
     term_width, _ = get_terminal_size()
     lwidth = 25
@@ -112,6 +114,7 @@ def calendar(collection, format=None, notstarted=False, once=False, daterange=No
                                      daterange=daterange, locale=locale,
                                      once=once, notstarted=notstarted,
                                      default_timedelta=td, width=rwidth,
+                                     show_all_days=show_all_days,
                                      **kwargs)
     calendar_column = calendar_display.vertical_month(
         firstweekday=firstweekday, weeknumber=weeknumber,
@@ -129,7 +132,8 @@ def calendar(collection, format=None, notstarted=False, once=False, daterange=No
 
 def get_list_from_str(collection, locale, daterange, notstarted=False,
                       format=None, day_format=None, once=False,
-                      default_timedelta=None, env=None, **kwargs):
+                      default_timedelta=None, env=None, show_all_days=False,
+                      **kwargs):
     """returns a list of events scheduled in between `daterange`.
 
     :param collection:
@@ -185,7 +189,7 @@ def get_list_from_str(collection, locale, daterange, notstarted=False,
             day_end = end
         current_events = get_list(collection, locale=locale, format=format, start=start,
                                   end=day_end, notstarted=notstarted, env=env, **kwargs)
-        if current_events:
+        if show_all_days or current_events:
             event_column.append(format_day(start, day_format, locale))
         event_column.extend(current_events)
         start = aux.datetime_fillin(start.date(), end=False) + timedelta(days=1)
@@ -253,16 +257,19 @@ def khal_list(collection, daterange, conf=None, format=None, day_format=None,
               once=False, notstarted=False, **kwargs):
     """list all events in `daterange`"""
     td = None
+    show_all_days = False
     if conf is not None:
         if format is None:
             format = conf['view']['agenda_event_format']
         td = conf['default']['timedelta']
         if day_format is None:
             day_format = conf['view']['agenda_day_format']
+        show_all_days = conf['default']['show_all_days']
 
     event_column = get_list_from_str(
         collection, format=format, day_format=day_format, daterange=daterange,
-        once=once, notstarted=notstarted, default_timedelta=td, **kwargs)
+        once=once, notstarted=notstarted, default_timedelta=td,
+        show_all_days=show_all_days, **kwargs)
 
     echo('\n'.join(event_column))
 

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -176,7 +176,8 @@ def agenda(collection, dates=None, show_all_days=False, full=False,
 
 
 def get_list_from_str(collection, locale, daterange, notstarted=False,
-                      format=None, once=False, default_timedelta=None, env=None):
+                      format=None, once=False, default_timedelta=None, env=None
+                      **kwargs):
     """returns a list of events scheduled in between `daterange`.
 
     :param collection:
@@ -230,17 +231,17 @@ def get_list_from_str(collection, locale, daterange, notstarted=False,
             if start.date() == end.date():
                 day_end = end
             event_column.extend(get_list(collection, locale=locale, format=format, start=start,
-                                         end=day_end, notstarted=notstarted, env=env))
+                                         end=day_end, notstarted=notstarted, env=env, **kwargs))
             start = aux.datetime_fillin(start.date(), end=False) + timedelta(days=1)
     else:
         event_column = get_list(collection, locale=locale, format=format, start=start,
-                                end=end, notstarted=notstarted)
+                                end=end, notstarted=notstarted, **kwargs)
     if event_column == []:
         event_column = [style('No events', bold=True)]
     return event_column
 
 
-def get_list(collection, locale, start, end, format=None, notstarted=False, env=None):
+def get_list(collection, locale, start, end, format=None, notstarted=False, env=None, width=None):
     """returns a list of events scheduled between start and end. Start and end
     are strings or datetimes (of some kind).
 
@@ -283,7 +284,10 @@ def get_list(collection, locale, start, end, format=None, notstarted=False, env=
                 logging.fatal(e)
                 sys.exit(1)
 
-            event_list.append(event_string)
+            if width:
+                event_list += textwrap.wrap(event_string, width)
+            else:
+                event_list.append(event_string)
 
     return event_list
 

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -27,7 +27,7 @@ from vdirsyncer.utils.vobject import Item
 from collections import defaultdict
 from shutil import get_terminal_size
 
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 import logging
 import sys
 import textwrap
@@ -131,27 +131,33 @@ def get_agenda(collection, locale, dates=None, firstweekday=0, days=None, events
     return event_column
 
 
-def calendar(collection, dates=None, firstweekday=0, locale=None,
-             weeknumber=False, show_all_days=False, conf=None,
+def calendar(collection, format=None, notstarted=False, once=False, daterange=None,
+             locale=None,
+             conf=None,
+             firstweekday=0,
+             weeknumber=False,
              hmethod='fg',
              default_color='',
              multiple='',
              color='',
              highlight_event_days=0,
-             week=False,
              full=False,
              bold_for_light_color=True,
              **kwargs):
-    if dates is None:
-        dates = [datetime.today()]
+    td = None
+    if conf is not None:
+        if format is None:
+            format = conf['view']['event_format']
+        td = conf['default']['timedelta']
 
     term_width, _ = get_terminal_size()
     lwidth = 25
     rwidth = term_width - lwidth - 4
-    event_column = get_agenda(
-        collection, locale, dates=dates, width=rwidth,
-        show_all_days=show_all_days, week=week, full=full,
-        bold_for_light_color=bold_for_light_color, **kwargs)
+    event_column = get_list_from_str(collection, format=format,
+                                     daterange=daterange, locale=locale,
+                                     once=once, notstarted=notstarted,
+                                     default_timedelta=td, width=rwidth,
+                                     **kwargs)
     calendar_column = calendar_display.vertical_month(
         firstweekday=firstweekday, weeknumber=weeknumber,
         collection=collection,
@@ -176,7 +182,7 @@ def agenda(collection, dates=None, show_all_days=False, full=False,
 
 
 def get_list_from_str(collection, locale, daterange, notstarted=False,
-                      format=None, once=False, default_timedelta=None, env=None
+                      format=None, once=False, default_timedelta=None, env=None,
                       **kwargs):
     """returns a list of events scheduled in between `daterange`.
 

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -548,10 +548,12 @@ class Event(object):
                 attributes["to-style"] + attributes["end-style"]
 
         attributes["recurse"] = self._recur_str
+        attributes["repeat-pattern"] = self.recurpattern
         attributes["title"] = self.summary
         attributes["description"] = self.description.strip()
         attributes["location"] = self.location.strip()
         attributes["all-day"] = allday
+        attributes["categories"] = self.categories
 
         attributes["calendar"] = self.calendar
         attributes["calendar-color"] = ""

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -529,7 +529,9 @@ class Event(object):
             attributes["start-style"] = attributes["start-time"]
             tostr = "-"
 
-        if self_end == day_end:
+        midnight_end = day_end.time() == time.max and self_end.time() == time.min and\
+                       self_end.date() - timedelta(days=1) == day_end.date()
+        if self_end == day_end or midnight_end:
             attributes["end-style"] = self.symbol_strings["range_end"]
             tostr = ""
         elif self_end > day_end:

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -476,7 +476,7 @@ class Event(object):
 
         try:
             relative_to_start, relative_to_end = relative_to
-        except:
+        except (TypeError, ValueError):
             relative_to_start = relative_to
             relative_to_end = relative_to
 
@@ -557,14 +557,12 @@ class Event(object):
 
         attributes["calendar"] = self.calendar
         attributes["calendar-color"] = ""
-        try:
+        if "calendars" in env and self.calendar in env["calendars"]:
             cal = env["calendars"][self.calendar]
             if "color" in cal and cal["color"] is not None:
                 attributes["calendar-color"] = get_color(cal["color"])
             if "displayname" in cal and cal["displayname"] is not None:
                 attributes["calendar"] = cal["displayname"]
-        except:
-            pass
 
         attributes["start-date-once"] = attributes["start-date"]
         if self_start.replace(tzinfo=None) < relative_to_start:
@@ -584,7 +582,7 @@ class Event(object):
         attributes.update(colors)
         try:
             return format_string.format(**attributes) + colors["reset"]
-        except:
+        except (KeyError, IndexError):
             raise KeyError("cannot format event with: %s" % format_string)
 
     @property

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -553,9 +553,9 @@ class Event(object):
         attributes["repeat-pattern"] = self.recurpattern
         attributes["title"] = self.summary
         attributes["description"] = self.description.strip()
-        attributes["description-seperator"] = ""
+        attributes["description-separator"] = ""
         if attributes["description"]:
-            attributes["description-seperator"] = " :: "
+            attributes["description-separator"] = " :: "
         attributes["location"] = self.location.strip()
         attributes["all-day"] = allday
         attributes["categories"] = self.categories

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -551,7 +551,9 @@ class Event(object):
         attributes["repeat-pattern"] = self.recurpattern
         attributes["title"] = self.summary
         attributes["description"] = self.description.strip()
-        attributes["description-seperator"] = " :: " if attributes["description"] else ""
+        attributes["description-seperator"] = ""
+        if attributes["description"]:
+            attributes["description-seperator"] = " :: "
         attributes["location"] = self.location.strip()
         attributes["all-day"] = allday
         attributes["categories"] = self.categories
@@ -564,21 +566,6 @@ class Event(object):
                 attributes["calendar-color"] = get_color(cal["color"])
             if "displayname" in cal and cal["displayname"] is not None:
                 attributes["calendar"] = cal["displayname"]
-
-        daynames = list(construct_daynames((self_start.date(), relative_to_start.date())))
-        attributes["start-date-once"] = attributes["start-date"]
-        attributes["start-dayname-once"] = daynames[0][1]
-        if self_start.replace(tzinfo=None) < relative_to_start:
-            attributes["start-date-once"] = relative_to_start.strftime(self._locale['dateformat'])
-            attributes["start-dayname-once"] = daynames[1][1]
-        attributes["start-date-once-newline"] = "\n"
-        if "seen-days" not in env:
-            env["seen-days"] = set()
-        if attributes["start-date-once"] in env["seen-days"]:
-            attributes["start-date-once"] = ""
-            attributes["start-dayname-once"] = ""
-            attributes["start-date-once-newline"] = ""
-        env["seen-days"].add(attributes["start-date-once"])
 
         colors = {"reset": style("", reset=True), "bold": style("", bold=True, reset=False)}
         for c in ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]:

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -175,7 +175,7 @@ print_new = option('event', 'path', 'False', default=False)
 highlight_event_days = boolean(default=False)
 
 # Default timedelta for use with daterange options
-timedelta = string(default='')
+timedelta = string(default='2d')
 
 # The view section contains configuration options that effect the visual appearance
 # when using ikhal

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -150,21 +150,11 @@ quit = force_list(default=list('q', 'Q'))
 [default]
 
 # command to be executed if no command is given when executing khal
-default_command = option('calendar', 'agenda', 'interactive', 'printformats', 'printcalendars', '', default='calendar')
+default_command = option('calendar', 'list', 'interactive', 'printformats', 'printcalendars', '', default='calendar')
 
 # The calendar to use if none is specified for some operation (e.g. if adding a
 # new event). If this is not set, such operations require an explicit value.
 default_calendar = string(default=None)
-
-# By default, khal displays only dates with event in "agenda" view.
-# Setting this to *True* will show all days in "agenda", even
-# when there is no event scheduled on that day.
-show_all_days = boolean(default=False)
-
-# By default, khal shows events for today and tomorrow.
-# Setting this to a different value will show events of that amount of days by
-# default.
-days = integer(default=2)
 
 # After adding a new event, what should be printed to standard out? The whole
 # event in text form, the path to where the event is now saved or nothing?

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -208,7 +208,8 @@ frame = option('False', 'width', 'color', 'top', default='False')
 bold_for_light_color = boolean(default=True)
 
 # Default format for events (used in list)
-agenda_event_format = string(default='{start-date-once-newline}{bold}{start-dayname-once}{reset}{start-date-once-newline}{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{reset}')
+agenda_event_format = string(default='{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{reset}')
+agenda_day_format = string(default='{bold}{name}{reset}')
 event_format = string(default='{calendar-color}{start}-{end} {title}{recurse}{description-seperator}{description}{reset}')
 
 # When highlight_event_days is enabled, this section specifies how is

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -156,6 +156,11 @@ default_command = option('calendar', 'list', 'interactive', 'printformats', 'pri
 # new event). If this is not set, such operations require an explicit value.
 default_calendar = string(default=None)
 
+# By default, khal displays only dates with event in "agenda" view.
+# Setting this to *True* will show all days in "agenda", even
+# when there is no event scheduled on that day.
+show_all_days = boolean(default=False)
+
 # After adding a new event, what should be printed to standard out? The whole
 # event in text form, the path to where the event is now saved or nothing?
 print_new = option('event', 'path', 'False', default=False)

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -208,7 +208,8 @@ frame = option('False', 'width', 'color', 'top', default='False')
 bold_for_light_color = boolean(default=True)
 
 # Default format for events (used in list)
-event_format = string(default='{start-date-once-newline}{bold}{start-dayname-once}{reset}{start-date-once-newline}{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{calendar-color}')
+agenda_event_format = string(default='{start-date-once-newline}{bold}{start-dayname-once}{reset}{start-date-once-newline}{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{reset}')
+event_format = string(default='{calendar-color}{start}-{end} {title}{recurse}{description-seperator}{description}{reset}')
 
 # When highlight_event_days is enabled, this section specifies how is
 # the highlighting rendered.

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -208,9 +208,9 @@ frame = option('False', 'width', 'color', 'top', default='False')
 bold_for_light_color = boolean(default=True)
 
 # Default format for events (used in list)
-agenda_event_format = string(default='{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{reset}')
+agenda_event_format = string(default='{calendar-color}{start-end-time-style:16} {title}{recurse}{description-separator}{description}{reset}')
 agenda_day_format = string(default='{bold}{name}{reset}')
-event_format = string(default='{calendar-color}{start}-{end} {title}{recurse}{description-seperator}{description}{reset}')
+event_format = string(default='{calendar-color}{start}-{end} {title}{recurse}{description-separator}{description}{reset}')
 
 # When highlight_event_days is enabled, this section specifies how is
 # the highlighting rendered.

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -218,7 +218,7 @@ frame = option('False', 'width', 'color', 'top', default='False')
 bold_for_light_color = boolean(default=True)
 
 # Default format for events (used in list)
-event_format = string(default='{start}-{end} {title}')
+event_format = string(default='{start-date-once-newline}{bold}{start-dayname-once}{reset}{start-date-once-newline}{calendar-color}{start-end-time-style:16} {title}{recurse}{description-seperator}{description}{calendar-color}')
 
 # When highlight_event_days is enabled, this section specifies how is
 # the highlighting rendered.

--- a/tests/aux.py
+++ b/tests/aux.py
@@ -21,6 +21,9 @@ locale = {'default_timezone': BERLIN,
           'weeknumbers': False,
           }
 
+locale['longdatetimeformat'] = locale['longdateformat']
+locale['datetimeformat'] = locale['longdateformat']
+
 SAMOA = pytz.timezone('Pacific/Samoa')
 LOCALE_SAMOA = {'default_timezone': SAMOA,
                 'local_timezone': SAMOA,

--- a/tests/aux_test.py
+++ b/tests/aux_test.py
@@ -7,7 +7,8 @@ import icalendar
 import pytz
 from freezegun import freeze_time
 
-from khal.aux import construct_event, guessdatetimefstr, guesstimedeltafstr
+from khal.aux import construct_event, guessdatetimefstr, guesstimedeltafstr,\
+     guessrangefstr
 from khal import aux
 from khal.exceptions import FatalError
 import pytest
@@ -123,6 +124,32 @@ class TestGuessTimedeltafstr(object):
     def test_same(self):
         assert timedelta(minutes=20) == \
             guesstimedeltafstr('10min 10minutes')
+
+
+class TestGuessRangefstr(object):
+    td_1d = timedelta(days=1)
+    today_start = datetime.combine(date.today(), time.min)
+    tomorrow_start = today_start + td_1d
+    today13 = datetime.combine(date.today(), time(13, 0))
+    today14 = datetime.combine(date.today(), time(14, 0))
+    tomorrow16 = datetime.combine(tomorrow, time(16, 0))
+    today16 = datetime.combine(date.today(), time(16, 0))
+    today17 = datetime.combine(date.today(), time(17, 0))
+
+    def test_today(self):
+        assert (self.today13, self.today14) == guessrangefstr('13:00 14:00', locale=locale_de)
+        assert (self.today_start, self.tomorrow_start) == \
+            guessrangefstr('today tomorrow', locale_de)
+
+    def test_tomorrow(self):
+        assert (self.today_start, self.tomorrow16) == \
+            guessrangefstr('today tomorrow 16:00', locale=locale_de)
+
+    def test_time_tomorrow(self):
+        assert (self.today16, self.tomorrow16) == \
+            guessrangefstr('16:00', locale=locale_de, default_timedelta="1d")
+        assert (self.today16, self.today17) == \
+            guessrangefstr('16:00 17:00', locale=locale_de, default_timedelta="1d")
 
 
 test_set_format_de = _create_testcases(

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -282,7 +282,7 @@ def test_at(runner):
         main_khal,
         'new {} 18:00 myevent'.format(now, end_date.strftime('%d.%m.%Y')).split())
     result = runner.invoke(main_khal, ['--color', 'at', '18:30'])
-    assert result.output.startswith('\x1b[34m18:00')
+    assert result.output.startswith('03.06. 18:00')
     assert not result.exception
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -92,10 +92,11 @@ def test_direct_modification(runner):
     cal_dt = _get_text('event_dt_simple')
     event = runner.calendars['one'].join('test.ics')
     event.write(cal_dt)
-    format = '{start-date-once}{start-date-once-newline}{start-end-time-style}: {title}'
-    result = runner.invoke(main_khal, ['list', '--format', format, '09.04.2014'])
+    format = '{start-end-time-style}: {title}'
+    args = ['list', '--format', format, '--day-format', '', '09.04.2014']
+    result = runner.invoke(main_khal, args)
     assert not result.exception
-    assert result.output == '09.04.2014\n09:30-10:30: An Event\n'
+    assert result.output == '\n09:30-10:30: An Event\n'
 
     os.remove(str(event))
     result = runner.invoke(main_khal, ['list'])
@@ -284,8 +285,10 @@ def test_list(runner):
         main_khal,
         'new {} 18:00 myevent'.format(now, end_date.strftime('%d.%m.%Y')).split())
     format = '{red}{start-end-time-style}{reset} {title} :: {description}'
-    result = runner.invoke(main_khal, ['--color', 'list', '--format', format, '18:30'])
-    assert result.output.startswith('\x1b[31m18:00-19:00\x1b[0m myevent :: \x1b[0m\n')
+    args = ['--color', 'list', '--format', format, '--day-format', 'header', '18:30']
+    result = runner.invoke(main_khal, args)
+    expected = 'header\x1b[0m\n\x1b[31m18:00-19:00\x1b[0m myevent :: \x1b[0m\n'
+    assert result.output.startswith(expected)
     assert not result.exception
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -281,8 +281,8 @@ def test_at(runner):
     result = runner.invoke(
         main_khal,
         'new {} 18:00 myevent'.format(now, end_date.strftime('%d.%m.%Y')).split())
-    result = runner.invoke(main_khal, ['--color', 'at', '18:30'])
-    assert result.output.startswith('03.06. 18:00')
+    result = runner.invoke(main_khal, ['--color', 'at', '--format', '{start-time}{title}', '18:30'])
+    assert result.output.startswith('18:00')
     assert not result.exception
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -32,16 +32,14 @@ def runner(tmpdir):
     calendar2 = tmpdir.mkdir('calendar2')
     calendar3 = tmpdir.mkdir('calendar3')
 
-    def inner(command='agenda', showalldays=False, days=2, default_calendar=True,
-              **kwargs):
+    def inner(command='list', default_calendar=True, days=2, **kwargs):
         if default_calendar:
             default_calendar = 'default_calendar = one'
         else:
             default_calendar = ''
         config.write(config_template.format(
             command=command,
-            showalldays=showalldays,
-            days=days,
+            delta=str(days)+'d',
             calpath=str(calendar), calpath2=str(calendar2), calpath3=str(calendar3),
             default_calendar=default_calendar,
             dbpath=str(db), **kwargs))
@@ -77,8 +75,7 @@ firstweekday = 0
 [default]
 default_command = {command}
 {default_calendar}
-show_all_days = {showalldays}
-days = {days}
+timedelta = {delta}
 
 [sqlite]
 path = {dbpath}
@@ -86,27 +83,28 @@ path = {dbpath}
 
 
 def test_direct_modification(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list')
 
-    result = runner.invoke(main_khal, ['agenda'])
+    result = runner.invoke(main_khal, ['list'])
     assert not result.exception
     assert result.output == 'No events\n'
 
     cal_dt = _get_text('event_dt_simple')
     event = runner.calendars['one'].join('test.ics')
     event.write(cal_dt)
-    result = runner.invoke(main_khal, ['agenda', '09.04.2014'])
+    format = '{start-date-once}{start-date-once-newline}{start-end-time-style}: {title}'
+    result = runner.invoke(main_khal, ['list', '--format', format, '09.04.2014'])
     assert not result.exception
     assert result.output == '09.04.2014\n09:30-10:30: An Event\n'
 
     os.remove(str(event))
-    result = runner.invoke(main_khal, ['agenda'])
+    result = runner.invoke(main_khal, ['list'])
     assert not result.exception
     assert result.output == 'No events\n'
 
 
 def test_simple(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
 
     result = runner.invoke(main_khal)
     assert not result.exception
@@ -127,7 +125,7 @@ def test_simple(runner):
 
 
 def test_simple_color(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
 
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     result = runner.invoke(main_khal, 'new {} 18:00 myevent'.format(now).split())
@@ -140,7 +138,7 @@ def test_simple_color(runner):
 
 
 def test_days(runner):
-    runner = runner(command='agenda', showalldays=False, days=9)
+    runner = runner(command='list', days=9)
 
     when = (datetime.datetime.now() + timedelta(days=7)).strftime('%d.%m.%Y')
     result = runner.invoke(main_khal, 'new {} 18:00 nextweek'.format(when).split())
@@ -159,17 +157,9 @@ def test_days(runner):
     assert not result.exception
 
 
-def test_showalldays(runner):
-    runner = runner(command='agenda', showalldays=True, days=2)
-
-    result = runner.invoke(main_khal)
-    assert 'Tomorrow:' in result.output
-    assert not result.exception
-
-
 def test_calendar(runner):
     with freeze_time('2015-6-1'):
-        runner = runner(command='calendar', showalldays=False, days=0)
+        runner = runner(command='calendar', days=0)
         result = runner.invoke(main_khal)
         assert not result.exception
         assert result.exit_code == 0
@@ -195,7 +185,7 @@ def test_calendar(runner):
 
 
 def test_default_command_empty(runner):
-    runner = runner(command='', showalldays=False, days=2)
+    runner = runner(command='', days=2)
 
     result = runner.invoke(main_khal)
     assert result.exception
@@ -204,7 +194,7 @@ def test_default_command_empty(runner):
 
 
 def test_default_command_nonempty(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
 
     result = runner.invoke(main_khal)
     assert not result.exception
@@ -212,7 +202,7 @@ def test_default_command_nonempty(runner):
 
 
 def test_invalid_calendar(runner):
-    runner = runner(command='', showalldays=False, days=2)
+    runner = runner(command='', days=2)
     result = runner.invoke(
         main_khal, ['new'] + '-a one 18:00 myevent'.split())
     assert not result.exception
@@ -224,7 +214,7 @@ def test_invalid_calendar(runner):
 
 
 def test_attach_calendar(runner):
-    runner = runner(command='calendar', showalldays=False, days=2)
+    runner = runner(command='calendar', days=2)
     result = runner.invoke(main_khal, ['printcalendars'])
     assert set(result.output.split('\n')[:3]) == set(['one', 'two', 'three'])
     assert not result.exception
@@ -241,7 +231,7 @@ def test_attach_calendar(runner):
     'BEGIN:VCALENDAR\nBEGIN:VTODO\nEND:VTODO\nEND:VCALENDAR\n'
 ])
 def test_no_vevent(runner, tmpdir, contents):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
     broken_item = runner.calendars['one'].join('broken_item.ics')
     broken_item.write(contents.encode('utf-8'), mode='wb')
 
@@ -251,7 +241,7 @@ def test_no_vevent(runner, tmpdir, contents):
 
 
 def test_printformats(runner):
-    runner = runner(command='printformats', showalldays=False, days=2)
+    runner = runner(command='printformats', days=2)
 
     result = runner.invoke(main_khal)
     assert '\n'.join(['longdatetimeformat: 21.12.2013 10:09',
@@ -264,7 +254,7 @@ def test_printformats(runner):
 
 
 def test_repeating(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     end_date = datetime.datetime.now() + datetime.timedelta(days=10)
     result = runner.invoke(
@@ -275,7 +265,7 @@ def test_repeating(runner):
 
 
 def test_at(runner):
-    runner = runner(command='calendar', showalldays=False, days=2)
+    runner = runner(command='calendar', days=2)
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     end_date = datetime.datetime.now() + datetime.timedelta(days=10)
     result = runner.invoke(
@@ -287,7 +277,7 @@ def test_at(runner):
 
 
 def test_list(runner):
-    runner = runner(command='calendar', showalldays=False, days=2)
+    runner = runner(command='calendar', days=2)
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     end_date = datetime.datetime.now() + datetime.timedelta(days=10)
     result = runner.invoke(
@@ -300,7 +290,7 @@ def test_list(runner):
 
 
 def test_search(runner):
-    runner = runner(command='calendar', showalldays=False, days=2)
+    runner = runner(command='calendar', days=2)
     now = datetime.datetime.now().strftime('%d.%m.%Y')
     result = runner.invoke(main_khal, 'new {} 18:00 myevent'.format(now).split())
     format = '{red}{start-end-time-style}{reset} {title} :: {description}'
@@ -351,7 +341,7 @@ def test_import(runner, monkeypatch):
 
 
 def test_interactive_command(runner, monkeypatch):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
     token = "hooray"
 
     def fake_ui(*a, **kw):
@@ -370,7 +360,7 @@ def test_interactive_command(runner, monkeypatch):
 
 
 def test_color_option(runner):
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
 
     result = runner.invoke(main_khal, ['--no-color'])
     assert result.output == 'No events\n'
@@ -388,7 +378,7 @@ def test_configure_command(runner, monkeypatch):
 
     monkeypatch.setattr('khal.configwizard.configwizard', hocus_pocus)
 
-    runner = runner(command='agenda', showalldays=False, days=2)
+    runner = runner(command='list', days=2)
     runner.config.remove()
 
     result = runner.invoke(main_khal, ['configure'])

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -271,9 +271,11 @@ def test_at(runner):
     end_date = datetime.datetime.now() + datetime.timedelta(days=10)
     result = runner.invoke(
         main_khal,
-        'new {} 18:00 myevent'.format(now, end_date.strftime('%d.%m.%Y')).split())
-    result = runner.invoke(main_khal, ['--color', 'at', '--format', '{start-time}{title}', '18:30'])
-    assert result.output.startswith('18:00')
+        'new {} {} 18:00 myevent'.format(now, end_date.strftime('%d.%m.%Y')).split())
+    args = ['--color', 'at', '--format', '{start-time}{title}', '--day-format', '', '18:30']
+    result = runner.invoke(main_khal, args)
+    print(result.output)
+    assert result.output.startswith('\x1b[0m\nmyevent')
     assert not result.exception
 
 

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -26,9 +26,8 @@ event_today = event_allday_template.format(today.strftime('%Y%m%d'),
                                            tomorrow.strftime('%Y%m%d'))
 item_today = Item(event_today)
 
-event_format = '{start-date-once-newline}{bold}{start-dayname-once}{reset}\
-{start-date-once-newline}{calendar-color}{start-end-time-style:16} {title}\
-{recurse}{description-seperator}{description}{calendar-color}'
+event_format = '{calendar-color}{start-end-time-style:16} {title}'
+event_format += '{recurse}{description-seperator}{description}{calendar-color}'
 
 
 class TestGetAgenda(object):
@@ -36,10 +35,10 @@ class TestGetAgenda(object):
         coll, vdirs = coll_vdirs
         event = coll.new_event(event_today, aux.cal1)
         coll.new(event)
-        assert ['\n'
-                '\x1b[1mToday:\x1b[0m\n'
+        assert ['\x1b[0m',
                 '                 a meeting :: short description\x1b[0m'] == \
-            get_list_from_str(coll, aux.locale, [], format=event_format, default_timedelta='1d')
+            get_list_from_str(coll, aux.locale, [], format=event_format, default_timedelta='1d',
+                              day_format="")
 
     def test_empty_recurrence(self, coll_vdirs):
         coll, vidrs = coll_vdirs

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -27,7 +27,7 @@ event_today = event_allday_template.format(today.strftime('%Y%m%d'),
 item_today = Item(event_today)
 
 event_format = '{calendar-color}{start-end-time-style:16} {title}'
-event_format += '{recurse}{description-seperator}{description}{calendar-color}'
+event_format += '{recurse}{description-separator}{description}{calendar-color}'
 
 
 class TestGetAgenda(object):

--- a/tests/controller_test.py
+++ b/tests/controller_test.py
@@ -57,7 +57,9 @@ class TestGetAgenda(object):
 class TestImport(object):
     def test_import(self, coll_vdirs):
         coll, vdirs = coll_vdirs
-        import_ics(coll, {'locale': aux.locale}, _get_text('event_rrule_recuid'),
+        view = {'event_format': '{title}'}
+        conf = {'locale': aux.locale, 'view': view}
+        import_ics(coll, conf, _get_text('event_rrule_recuid'),
                    batch=True)
         start_date = aux.BERLIN.localize(datetime.datetime(2014, 4, 30))
         end_date = aux.BERLIN.localize(datetime.datetime(2014, 9, 26))
@@ -68,7 +70,7 @@ class TestImport(object):
         assert aux.BERLIN.localize(datetime.datetime(2014, 7, 14, 7, 0)) in \
             [ev.start for ev in events]
 
-        import_ics(coll, {'locale': aux.locale}, _get_text('event_rrule_recuid_update'),
+        import_ics(coll, conf, _get_text('event_rrule_recuid_update'),
                    batch=True)
         events = list(coll.get_localized(start_date, end_date))
         for ev in events:
@@ -82,9 +84,10 @@ class TestImport(object):
         Test importing events with mixed tz-aware and tz-naive datetimes.
         """
         coll, vdirs = coll_vdirs
+        view = {'event_format': '{title}'}
         import_ics(
             coll,
-            {'locale': aux.locale},
+            {'locale': aux.locale, 'view': view},
             _get_text('event_dt_mixed_awareness'),
             batch=True
         )

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -43,7 +43,7 @@ class TestSettings(object):
                 'print_new': 'False',
                 'days': 2,
                 'highlight_event_days': False,
-                'timedelta': ''
+                'timedelta': '2d'
             }
         }
         for key in comp_config:
@@ -83,7 +83,7 @@ class TestSettings(object):
                 'show_all_days': False,
                 'days': 2,
                 'highlight_event_days': False,
-                'timedelta': ''
+                'timedelta': '2d'
             }
         }
         for key in comp_config:

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -39,9 +39,7 @@ class TestSettings(object):
             'default': {
                 'default_command': 'calendar',
                 'default_calendar': None,
-                'show_all_days': False,
                 'print_new': 'False',
-                'days': 2,
                 'highlight_event_days': False,
                 'timedelta': '2d'
             }
@@ -80,8 +78,6 @@ class TestSettings(object):
                 'default_calendar': None,
                 'default_command': 'calendar',
                 'print_new': 'False',
-                'show_all_days': False,
-                'days': 2,
                 'highlight_event_days': False,
                 'timedelta': '2d'
             }

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -41,7 +41,8 @@ class TestSettings(object):
                 'default_calendar': None,
                 'print_new': 'False',
                 'highlight_event_days': False,
-                'timedelta': '2d'
+                'timedelta': '2d',
+                'show_all_days': False
             }
         }
         for key in comp_config:
@@ -79,7 +80,8 @@ class TestSettings(object):
                 'default_command': 'calendar',
                 'print_new': 'False',
                 'highlight_event_days': False,
-                'timedelta': '2d'
+                'timedelta': '2d',
+                'show_all_days': False
             }
         }
         for key in comp_config:


### PR DESCRIPTION
I have replaced the at code with a simple call to list, and given it format
options. This includes a `--notstarted` flag, which I think will be nice.

To get the same feel as the previous at command, the format string should be
set to:

`"{start}-{end}: {title}\nLocation: {location}\nCategories:
{categories}\nRepeat: {repeat-pattern}\nDescription: {description}"`

this will not have the lines removed with no values like at currently does, but
it is close and I think it is worth sacrificing for consistency.