### PR TITLE
add command edit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ not released yet
 * renamed `agenda` to `list` (Taylor Money)
 * removed `days` configuration option in favor of `timedelta`, see
   documentation for details (Taylor Money)
-
+* added command `edit` (Taylor Money)
 
 ikhal
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ not released yet
 * removed `days` configuration option in favor of `timedelta`, see
   documentation for details (Taylor Money)
 * added command `edit` (Taylor Money)
+* `new` has interactive option (Taylor Money)
 
 ikhal
 -----

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -407,6 +407,18 @@ additional description
 adds a new all day event on 26th of July to the calendar *work* which recurs
 every week.
 
+
+edit
+****
+an interactive command for editing and deleting events using a search string
+
+::
+
+    khal edit [--hide-past] event_search_string
+
+the command will loop through all events that match the search string,
+prompting the user to delete, or change attributes.
+
 printcalendars
 **************
 prints a list of all configured calendars.

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -318,8 +318,8 @@ allows for adding new events. ``khal new`` should understand the following synta
 
 ::
 
-    khal new [-a CALENDAR] [OPTIONS] [START] [END | DELTA] [TIMEZONE] [SUMMARY]
-    [:: DESCRIPTION]
+    khal new [-a CALENDAR] [OPTIONS] [START [END | DELTA] [TIMEZONE] SUMMARY
+    [:: DESCRIPTION]]
 
 where start- and enddatetime are either datetimes, times, or keywords and times
 in the formats defined in the config file. If no calendar is given via
@@ -419,7 +419,7 @@ an interactive command for editing and deleting events using a search string
 
 ::
 
-    khal edit [--hide-past] event_search_string
+    khal edit [--show-past] event_search_string
 
 the command will loop through all events that match the search string,
 prompting the user to delete, or change attributes.

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -318,7 +318,8 @@ allows for adding new events. ``khal new`` should understand the following synta
 
 ::
 
-    khal new [-a CALENDAR] [OPTIONS] startdatetime [enddatetime] [timezone] summary [description]
+    khal new [-a CALENDAR] [OPTIONS] [START] [END | DELTA] [TIMEZONE] [SUMMARY]
+    [:: DESCRIPTION]
 
 where start- and enddatetime are either datetimes, times, or keywords and times
 in the formats defined in the config file. If no calendar is given via
@@ -360,6 +361,10 @@ accepted as the end of a given date.
 If the **summary** contains the string `::`, everything after `::` is taken as
 the **description** of the new event, i.e., the "body" of the event (and `::`
 will be removed).
+
+Passing the option `--interactive` (`-i`) makes all arguments optional and
+interactively prompts for required fields, then the event may be edited, the
+same way as in the `edit` command.
 
 Options
 """""""

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -237,6 +237,35 @@ def guessdatetimefstr(dtime_list, locale, default_day=None):
     raise ValueError()
 
 
+def timedelta2str(delta):
+    total_seconds = abs(delta).seconds
+
+    seconds = total_seconds % 60
+    total_seconds -= seconds
+    total_minutes = total_seconds//60
+    minutes = total_minutes % 60
+    total_minutes -= minutes
+    total_hours = total_minutes // 60
+    hours = total_hours % 24
+    total_hours -= hours
+    days = total_hours // 24
+
+    s = []
+    if days:
+        s.append(str(days) + "d")
+    if hours:
+        s.append(str(hours) + "h")
+    if minutes:
+        s.append(str(minutes) + "m")
+    if seconds:
+        s.append(str(seconds) + "s")
+
+    if delta != abs(delta):
+        s = ["-"+part for part in s]
+
+    return ' '.join(s)
+
+
 def guesstimedeltafstr(delta_string):
     """parses a timedelta from a string
 
@@ -267,6 +296,9 @@ def guesstimedeltafstr(delta_string):
         elif (ulower == 'm' or ulower == 'minute' or ulower == 'minutes' or
               ulower == 'min'):
             res += timedelta(minutes=numint)
+        elif (ulower == 's' or ulower == 'second' or ulower == 'seconds' or
+              ulower == 'sec'):
+            res += timedelta(seconds=numint)
         else:
             raise ValueError('Invalid unit in timedelta string "%s": "%s"'
                              % (delta_string, unit))

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -542,8 +542,12 @@ def new_event(locale, dtstart=None, dtend=None, summary=None, timezone=None,
     :rtype: icalendar.Event
     """
 
-    if dtstart is None or dtend is None or summary is None:
-        raise ValueError
+    if dtstart is None:
+        raise ValueError("no start given")
+    if dtend is None:
+        raise ValueError("no end given")
+    if summary is None:
+        raise ValueError("no summary given")
 
     if not allday and timezone is not None:
         dtstart = timezone.localize(dtstart)

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -328,9 +328,10 @@ def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
     except ValueError:
         default_timedelta = None
 
-    for i in range(1, len(range_list) + 1):
+    for i in reversed(range(1, len(range_list) + 1)):
         start = ' '.join(range_list[:i])
         end = ' '.join(range_list[i:])
+        allday = False
         try:
             if start is None:
                 start = datetime_fillin(end=False)
@@ -341,7 +342,7 @@ def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
                     end = start + timedelta(days=7)
                 else:
                     split = start.split(" ")
-                    start = guessdatetimefstr(split, locale)[0]
+                    start, allday = guessdatetimefstr(split, locale)
                     if len(split) != 0:
                         continue
 
@@ -365,15 +366,15 @@ def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
                         end = start + delta
                     except ValueError:
                         split = end.split(" ")
-                        end = guessdatetimefstr(split, locale, default_day=start.date())[0]
+                        end, end_allday = guessdatetimefstr(split, locale, default_day=start.date())
                         if len(split) != 0:
                             continue
                     end = datetime_fillin(end)
-            return start, end
+            return start, end, allday
         except ValueError:
             pass
 
-    return None, None
+    return None, None, False
 
 
 def datetime_fillin(dt=None, end=True, locale=None, day=None):
@@ -435,7 +436,7 @@ def rrulefstr(repeat, until, locale):
                                  (datetimefstr, locale['dateformat']),
                                  (datetimefstr, locale['longdateformat'])]:
                 try:
-                    until_date = fun(until, dformat)
+                    until_date = fun(until.split(' '), dformat)
                     break
                 except ValueError:
                     pass

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -474,12 +474,29 @@ def rrulefstr(repeat, until, locale):
 
 def eventinfofstr(info_string, locale, default_timedelta=None,
                   adjust_reasonably=False, localize=False):
+    """parses a string of the form [START [END | DELTA]] [SUMMARY] [::
+    DESCRIPTION] into a dictionary with keys: dtstart, dtend, timezone, allday,
+    summary, description
+
+    :param info_string:
+    :type info_string: string fitting the form
+    :param locale:
+    :type locale: locale
+    :param default_timedelta:
+    :type default_timedelta: passed on to guessrangefstr
+    :param adjust_reasonably:
+    :type adjust_reasonably: passed on to guessrangefstr
+    :param localize:
+    :type localize: boolean controls whether dates are localized in the end
+    :rtype: dictionary
+
+    """
     description = None
     if " :: " in info_string:
         info_string, description = info_string.split(' :: ')
 
     parts = info_string.split(' ')
-    title = None
+    summary = None
     start = None
     end = None
     tz = None
@@ -494,9 +511,9 @@ def eventinfofstr(info_string, locale, default_timedelta=None,
                 i += 1
             except (pytz.UnknownTimeZoneError, UnicodeDecodeError, IndexError):
                 tz = None
-            title = ' '.join(parts[i:])
+            summary = ' '.join(parts[i:])
             break
-        title = ' '.join(parts[i:])
+        summary = ' '.join(parts[i:])
 
     if start is not None and end is not None:
         if tz is None:
@@ -513,7 +530,7 @@ def eventinfofstr(info_string, locale, default_timedelta=None,
     info = {}
     info["dtstart"] = start
     info["dtend"] = end
-    info["summary"] = title
+    info["summary"] = summary if summary else None
     info["description"] = description
     info["timezone"] = tz if not allday else None
     info["allday"] = allday

--- a/khal/aux.py
+++ b/khal/aux.py
@@ -306,7 +306,8 @@ def guesstimedeltafstr(delta_string):
     return res
 
 
-def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
+def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0,
+                   adjust_reasonably=False):
     """parses a range string
 
     :param daterange: date1 [date2 | timedelta]
@@ -370,6 +371,24 @@ def guessrangefstr(daterange, locale, default_timedelta=None, first_weekday=0):
                         if len(split) != 0:
                             continue
                     end = datetime_fillin(end)
+
+            if adjust_reasonably:
+                if allday:
+                    end += timedelta(days=1)
+                    # test if end's year is this year, but start's year is not
+                    today = datetime.today()
+                    if end.year == today.year and start.year != today.year:
+                        end = datetime(start.year, *end.timetuple()[1:6])
+
+                    if end < start:
+                        end = datetime(end.year + 1, *end.timetuple()[1:6])
+
+                if end < start:
+                    end = datetime(*start.timetuple()[0:3] +
+                                   end.timetuple()[3:5])
+                if end < start:
+                    end = end + timedelta(days=1)
+
             return start, end, allday
         except ValueError:
             pass
@@ -453,140 +472,57 @@ def rrulefstr(repeat, until, locale):
         raise FatalError()
 
 
-def construct_event(dtime_list, locale,
-                    defaulttimelen=60, defaultdatelen=1, description=None,
-                    location=None, categories=None, repeat=None, until=None,
-                    alarm=None, **kwargs):
-    """takes a list of strings and constructs a vevent from it
+def eventinfofstr(info_string, locale, default_timedelta=None,
+                  adjust_reasonably=False, localize=False):
+    description = None
+    if " :: " in info_string:
+        info_string, description = info_string.split(' :: ')
 
-    the parts of the list can be either of these:
-        * datetime datetime description
-            start and end datetime specified, if no year is given, this year
-            is used, if the second datetime has no year, the same year as for
-            the first datetime object will be used, unless that would make
-            the event end before it begins, in which case the next year is
-            used
-        * datetime time description
-            end date will be same as start date, unless that would make the
-            event end before it has started, then the next day is used as
-            end date
-        * datetime description
-            event will last for defaulttime
-        * time time description
-            event starting today at the first time and ending today at the
-            second time, unless that would make the event end before it has
-            started, then the next day is used as end date
-        * time description
-            event starting today at time, lasting for the default length
-        * date date description
-            all day event starting on the first and ending on the last event
-        * date description
-            all day event starting at given date and lasting for default length
+    parts = info_string.split(' ')
+    title = None
+    start = None
+    end = None
+    tz = None
+    allday = False
+    for i in reversed(range(len(parts)+1)):
+        start, end, allday = guessrangefstr(' '.join(parts[0:i]), locale, default_timedelta='60m',
+                                            adjust_reasonably=adjust_reasonably)
+        if start is not None and end is not None:
+            try:
+                # next element is a valid Olson db timezone string
+                tz = pytz.timezone(parts[i])
+                i += 1
+            except (pytz.UnknownTimeZoneError, UnicodeDecodeError, IndexError):
+                tz = None
+            title = ' '.join(parts[i:])
+            break
+        title = ' '.join(parts[i:])
 
-    datetime should match datetimeformat or longdatetimeformat
-    time should match timeformat
+    if start is not None and end is not None:
+        if tz is None:
+            tz = locale['default_timezone']
 
-    where description is the unused part of the list
-    see tests for examples
-
-    """
-    # TODO remove if this survives for some time in the wild without getting any reports
-    first_type = type(dtime_list[0])
-    try:
-        for part in dtime_list:
-            assert first_type == type(part)
-    except AssertionError:
-        logger.error(
-            "An internal error occured, please report the below error message "
-            "to khal's developers at https://github.com/pimutils/khal/issues or "
-            "via email at khal@lostpackets.de")
-        logger.error(' '.join(['{} ({})'.format(part, type(part)) for part in dtime_list]))
-
-    today = datetime.today()
-    try:
-        dtstart, all_day = guessdatetimefstr(dtime_list, locale)
-    except ValueError:
-        logger.fatal("Cannot parse: '{}'\nPlease have a look at "
-                     "the documentation.".format(' '.join(dtime_list)))
-        raise FatalError()
-
-    try:
-        dtend, _ = guessdatetimefstr(dtime_list, locale, dtstart)
-    except ValueError:
-        if all_day:
-            dtend = dtstart + timedelta(days=defaultdatelen - 1)
+        if allday:
+            start = start.date()
+            end = end.date()
         else:
-            dtend = dtstart + timedelta(minutes=defaulttimelen)
+            if localize:
+                start = tz.localize(start)
+                end = tz.localize(end)
 
-    if all_day:
-        dtend += timedelta(days=1)
-        # test if dtend's year is this year, but dtstart's year is not
-        if dtend.year == today.year and dtstart.year != today.year:
-            dtend = datetime(dtstart.year, *dtend.timetuple()[1:6])
-
-        if dtend < dtstart:
-            dtend = datetime(dtend.year + 1, *dtend.timetuple()[1:6])
-
-    if dtend < dtstart:
-        dtend = datetime(*dtstart.timetuple()[0:3] +
-                         dtend.timetuple()[3:5])
-    if dtend < dtstart:
-        dtend = dtend + timedelta(days=1)
-    if all_day:
-        dtstart = dtstart.date()
-        dtend = dtend.date()
-
-    else:
-        if not dtime_list:
-            logger.fatal('No event summary provided, aborting.')
-            raise FatalError
-        try:
-            # next element is a valid Olson db timezone string
-            dtstart = pytz.timezone(dtime_list[0]).localize(dtstart)
-            dtend = pytz.timezone(dtime_list[0]).localize(dtend)
-            dtime_list.pop(0)
-        except (pytz.UnknownTimeZoneError, UnicodeDecodeError):
-            dtstart = locale['default_timezone'].localize(dtstart)
-            dtend = locale['default_timezone'].localize(dtend)
-
-    event = icalendar.Event()
-    text = ' '.join(dtime_list)
-    if not description or not location:
-        summary = text.split(' :: ', 1)[0]
-        try:
-            description = text.split(' :: ', 1)[1]
-        except IndexError:
-            pass
-    else:
-        summary = text
-
-    if description:
-        event.add('description', description)
-    if location:
-        event.add('location', location)
-    if categories:
-        event.add('categories', categories)
-    if repeat and repeat != "none":
-        rrule = rrulefstr(repeat, until, locale)
-        event.add('rrule', rrule)
-    if alarm:
-        alarm_trig = -1 * guesstimedeltafstr(alarm)
-        new_alarm = icalendar.Alarm()
-        new_alarm.add('ACTION', 'DISPLAY')
-        new_alarm.add('TRIGGER', alarm_trig)
-        new_alarm.add('DESCRIPTION', description)
-        event.add_component(new_alarm)
-
-    event.add('dtstart', dtstart)
-    event.add('dtend', dtend)
-    event.add('dtstamp', datetime.now())
-    event.add('summary', summary)
-    event.add('uid', generate_random_uid())  # TODO add proper UID
-    return event
+    info = {}
+    info["dtstart"] = start
+    info["dtend"] = end
+    info["summary"] = title
+    info["description"] = description
+    info["timezone"] = tz if not allday else None
+    info["allday"] = allday
+    return info
 
 
-def new_event(dtstart=None, dtend=None, summary=None, timezone=None,
-              allday=False):
+def new_event(locale, dtstart=None, dtend=None, summary=None, timezone=None,
+              allday=False, description=None, location=None, categories=None,
+              repeat=None, until=None, alarms=None):
     """create a new event
 
     :param dtstart: starttime of that event
@@ -605,31 +541,40 @@ def new_event(dtstart=None, dtend=None, summary=None, timezone=None,
     :returns: event
     :rtype: icalendar.Event
     """
-    now = datetime.now().timetuple()
-    now = datetime(now.tm_year, now.tm_mon, now.tm_mday, now.tm_hour)
-    inonehour = now + timedelta(minutes=60)
-    if dtstart is None:
-        dtstart = inonehour
-    elif isinstance(dtstart, date) and not allday:
-        time_start = inonehour.time()
-        dtstart = datetime.combine(dtstart, time_start)
 
-    if dtend is None:
-        dtend = dtstart + timedelta(minutes=60)
-    if allday:
-        dtend += timedelta(days=1)
-    if summary is None:
-        summary = ''
-    if timezone is not None:
+    if dtstart is None or dtend is None or summary is None:
+        raise ValueError
+
+    if not allday and timezone is not None:
         dtstart = timezone.localize(dtstart)
         dtend = timezone.localize(dtend)
+
     event = icalendar.Event()
     event.add('dtstart', dtstart)
     event.add('dtend', dtend)
     event.add('dtstamp', datetime.now())
     event.add('summary', summary)
     event.add('uid', generate_random_uid())
-    event.add('sequence', 0)
+    # event.add('sequence', 0)
+
+    if description:
+        event.add('description', description)
+    if location:
+        event.add('location', location)
+    if categories:
+        event.add('categories', categories)
+    if repeat and repeat != "none":
+        rrule = rrulefstr(repeat, until, locale)
+        event.add('rrule', rrule)
+    if alarms:
+        for alarm in alarms.split(","):
+            alarm = alarm.strip()
+            alarm_trig = -1 * guesstimedeltafstr(alarm)
+            new_alarm = icalendar.Alarm()
+            new_alarm.add('ACTION', 'DISPLAY')
+            new_alarm.add('TRIGGER', alarm_trig)
+            new_alarm.add('DESCRIPTION', description)
+            event.add_component(new_alarm)
     return event
 
 

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -329,7 +329,7 @@ def _get_cli():
                   help=('The format to print the event.'))
     @click.option('--alarms', '-m',
                   help=('Alarm times for the new event as DELTAs comma separated'))
-    @click.argument('info', metavar='[START] [END | DELTA] [TIMEZONE] [SUMMARY] [:: DESCRIPTION]',
+    @click.argument('info', metavar='[START [END | DELTA] [TIMEZONE] [SUMMARY] [:: DESCRIPTION]]',
                     nargs=-1)
     @click.pass_context
     def new(ctx, calendar, info, location, categories, repeat, until, alarms, format, interactive):
@@ -341,11 +341,10 @@ def _get_cli():
         assumed to be the event's summary, if two colons (::) are present,
         everything behind them is taken as the event's description.
         '''
-        # ugly hack to change how click presents the help string
         if not info and not interactive:
                 raise click.BadParameter(
                     'no details provided, '
-                    'did you mean to use --interactive/-i'
+                    'did you mean to use --interactive/-i?'
                 )
 
         calendar = calendar or ctx.obj['conf']['default']['default_calendar']
@@ -504,17 +503,17 @@ def _get_cli():
     @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
-    @click.option('--hide-past', help=('Show events that have already occured as options'),
+    @click.option('--show-past', help=('Show events that have already occured as options'),
                   is_flag=True)
     @click.argument('search_string', nargs=-1)
     @click.pass_context
-    def edit(ctx, format, search_string, hide_past):
+    def edit(ctx, format, search_string, show_past):
         '''Interactively edit (or delete) events matching the search string.'''
         controllers.edit(
             build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
             ' '.join(search_string),
             format=format,
-            allow_past=not hide_past,
+            allow_past=show_past,
             locale=ctx.obj['conf']['locale'],
             conf=ctx.obj['conf']
         )

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -323,18 +323,14 @@ def _get_cli():
                   help=('Repeat event: daily, weekly, monthly or yearly.'))
     @click.option('--until', '-u',
                   help=('Stop an event repeating on this date.'))
-    @click.option('--alarm', '-m',
-                  help=('Alarm time for the new event.'))
     @click.option('--format', '-f',
                   help=('The format to print the event.'))
-    @click.argument('START', nargs=1, required=True)
-    @click.argument('END', nargs=1, required=False)
-    @click.argument('TIMEZONE', nargs=1, required=False)
-    @click.argument('SUMMARY', metavar='SUMMARY', nargs=1, required=False)
-    @click.argument('DESCRIPTION', metavar='[:: DESCRIPTION]', nargs=-1, required=False)
+    @click.option('--alarms', '-m',
+                  help=('Alarm times for the new event as DELTAs comma seperated'))
+    @click.argument('info', metavar='[START] [END | DELTA] [TIMEZONE] [SUMMARY] [:: DESCRIPTION]',
+                    nargs=-1)
     @click.pass_context
-    def new(ctx, calendar, start, end, timezone, summary, description, location, categories, repeat,
-            until, alarm, format):
+    def new(ctx, calendar, info, location, categories, repeat, until, alarms, format):
         '''Create a new event from arguments.
 
         START and END can be either dates, times or datetimes, please have a
@@ -344,8 +340,6 @@ def _get_cli():
         everything behind them is taken as the event's description.
         '''
         # ugly hack to change how click presents the help string
-        eventlist = [start, end, timezone, summary] + list(description)
-        eventlist = [element for element in eventlist if element is not None]
         calendar = calendar or ctx.obj['conf']['default']['default_calendar']
         if calendar is None:
             raise click.BadParameter(
@@ -357,13 +351,14 @@ def _get_cli():
             build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
             calendar,
             ctx.obj['conf'],
-            eventlist,
+            info=' '.join(info),
             location=location,
             categories=categories,
             repeat=repeat,
-            until=until.split(' ') if until is not None else None,
-            alarm=alarm,
-            env={"calendars": ctx.obj['conf']['calendars']}
+            env={"calendars": ctx.obj['conf']['calendars']},
+            until=until,
+            alarms=alarms,
+            format=format,
         )
 
     @cli.command('import')

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -315,6 +315,8 @@ def _get_cli():
 
     @cli.command()
     @calendar_option
+    @click.option('--interactive', '-i', help=('Add event interactively'),
+                  is_flag=True)
     @click.option('--location', '-l',
                   help=('The location of the new event.'))
     @click.option('--categories', '-g',
@@ -330,7 +332,7 @@ def _get_cli():
     @click.argument('info', metavar='[START] [END | DELTA] [TIMEZONE] [SUMMARY] [:: DESCRIPTION]',
                     nargs=-1)
     @click.pass_context
-    def new(ctx, calendar, info, location, categories, repeat, until, alarms, format):
+    def new(ctx, calendar, info, location, categories, repeat, until, alarms, format, interactive):
         '''Create a new event from arguments.
 
         START and END can be either dates, times or datetimes, please have a
@@ -342,10 +344,13 @@ def _get_cli():
         # ugly hack to change how click presents the help string
         calendar = calendar or ctx.obj['conf']['default']['default_calendar']
         if calendar is None:
-            raise click.BadParameter(
-                'No default calendar is configured, '
-                'please provide one explicitly.'
-            )
+            if interactive:
+                calendar = click.prompt('calendar')
+            else:
+                raise click.BadParameter(
+                    'No default calendar is configured, '
+                    'please provide one explicitly.'
+                )
 
         controllers.new_from_string(
             build_collection(ctx.obj['conf'], ctx.obj.get('calendar_selection', None)),
@@ -359,6 +364,7 @@ def _get_cli():
             until=until,
             alarms=alarms,
             format=format,
+            interactive=interactive,
         )
 
     @cli.command('import')

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -487,6 +487,25 @@ def _get_cli():
     @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
+    @click.option('--hide-past', help=('Show events that have already occured as options'),
+                  is_flag=True)
+    @click.argument('search_string', nargs=-1)
+    @click.pass_context
+    def edit(ctx, format, search_string, hide_past):
+        '''Interactively edit (or delete) events matching the search string.'''
+        controllers.edit(
+            build_collection(ctx),
+            ' '.join(search_string),
+            format=format,
+            allow_past=not hide_past,
+            locale=ctx.obj['conf']['locale'],
+            conf=ctx.obj['conf']
+        )
+
+    @cli.command()
+    @multi_calendar_option
+    @click.option('--format', '-f',
+                  help=('The format of the events.'))
     @click.option('--day-format', '-df',
                   help=('The format of the day line.'))
     @click.option('--notstarted', help=('Print only events that have not started'),

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -304,6 +304,8 @@ def new_interactive(collection, calendar_name, conf, info, location=None,
                           location=location, categories=categories,
                           repeat=repeat, until=until, alarms=alarms, **info)
 
+    echo("event saved")
+
     term_width, _ = get_terminal_size()
     edit_event(event, collection, conf['locale'], width=term_width)
 
@@ -373,7 +375,10 @@ def present_options(options, prefix="", sep="  ", width=70):
 
 def edit_event(event, collection, locale, allow_quit=False, width=80):
     options = OrderedDict()
-    options["no"] = {"short": "n"}
+    if allow_quit:
+        options["no"] = {"short": "n"}
+    else:
+        options["done"] = {"short": "n"}
     options["summary"] = {"short": "s", "attr": "summary"}
     options["description"] = {"short": "d", "attr": "description", "none": True}
     options["datetime range"] = {"short": "t"}

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -255,19 +255,19 @@ def khal_list(collection, daterange, conf=None, format=None, day_format=None,
     echo('\n'.join(event_column))
 
 
-def new_from_string(collection, calendar_name, conf, date_list, location=None,
-                    categories=None, repeat=None, until=None, alarm=None,
+def new_from_string(collection, calendar_name, conf, info, location=None,
+                    categories=None, repeat=None, until=None, alarms=None,
                     format=None, env=None):
     """construct a new event from a string and add it"""
     try:
-        event = aux.construct_event(
-            date_list,
-            location=location,
-            categories=categories,
-            repeat=repeat,
-            until=until,
-            alarm=alarm,
-            locale=conf['locale'])
+        info = aux.eventinfofstr(info, conf['locale'], default_timedelta="60m",
+                                 adjust_reasonably=True, localize=False)
+        event = aux.new_event(locale=conf['locale'], location=location,
+                              categories=categories, repeat=repeat, until=until,
+                              alarms=alarms, **info)
+    except ValueError:
+        logger.fatal('ERROR: ')
+        sys.exit(1)
     except FatalError:
         sys.exit(1)
     event = Event.fromVEvents(
@@ -279,6 +279,7 @@ def new_from_string(collection, calendar_name, conf, date_list, location=None,
         logger.fatal('ERROR: Cannot modify calendar "{}" as it is '
                      'read-only'.format(calendar_name))
         sys.exit(1)
+
     if conf['default']['print_new'] == 'event':
         if format is None:
             format = conf['view']['event_format']

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -19,7 +19,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 import signal
 import sys
 
@@ -386,10 +386,14 @@ class EventColumn(urwid.WidgetWrap):
             self.pane.window.alert(('light red', 'No writable calendar.'))
             return
         if end is None:
-            event = aux.new_event(
-                dtstart=date, timezone=self.pane.conf['locale']['default_timezone'])
+            start = datetime.combine(date, datetime.now().time())
+            end = start + timedelta(minutes=60)
+            event = aux.new_event(dtstart=start, dtend=end, summary="new event",
+                                  timezone=self.pane.conf['locale']['default_timezone'],
+                                  locale=self.pane.conf['locale'])
         else:
-            event = aux.new_event(dtstart=date, dtend=end, allday=True)
+            event = aux.new_event(dtstart=date, dtend=end, summary="new event",
+                                  allday=True, locale=self.pane.conf['locale'])
 
         event = self.pane.collection.new_event(
             event.to_ical(), self.pane.collection.default_calendar_name)

--- a/tests/aux_test.py
+++ b/tests/aux_test.py
@@ -7,8 +7,8 @@ import icalendar
 import pytz
 from freezegun import freeze_time
 
-from khal.aux import construct_event, guessdatetimefstr, guesstimedeltafstr,\
-     guessrangefstr
+from khal.aux import construct_event, guessdatetimefstr, guesstimedeltafstr
+from khal.aux import timedelta2str, guessrangefstr
 from khal import aux
 from khal.exceptions import FatalError
 import pytest
@@ -150,6 +150,19 @@ class TestGuessRangefstr(object):
             guessrangefstr('16:00', locale=locale_de, default_timedelta="1d")
         assert (self.today16, self.today17) == \
             guessrangefstr('16:00 17:00', locale=locale_de, default_timedelta="1d")
+
+
+class TestTimeDelta2Str(object):
+
+    def test_single(self):
+        assert timedelta2str(timedelta(minutes=10)) == '10m'
+
+    def test_negative(self):
+        assert timedelta2str(timedelta(minutes=-10)) == '-10m'
+
+    def test_multi(self):
+        assert timedelta2str(timedelta(days=1, hours=-3, minutes=10, seconds=-3))\
+               == '21h 9m 57s'
 
 
 test_set_format_de = _create_testcases(

--- a/tests/aux_test.py
+++ b/tests/aux_test.py
@@ -137,18 +137,19 @@ class TestGuessRangefstr(object):
     today17 = datetime.combine(date.today(), time(17, 0))
 
     def test_today(self):
-        assert (self.today13, self.today14) == guessrangefstr('13:00 14:00', locale=locale_de)
-        assert (self.today_start, self.tomorrow_start) == \
+        assert (self.today13, self.today14, False) == \
+            guessrangefstr('13:00 14:00', locale=locale_de)
+        assert (self.today_start, self.tomorrow_start, True) == \
             guessrangefstr('today tomorrow', locale_de)
 
     def test_tomorrow(self):
-        assert (self.today_start, self.tomorrow16) == \
+        assert (self.today_start, self.tomorrow16, True) == \
             guessrangefstr('today tomorrow 16:00', locale=locale_de)
 
     def test_time_tomorrow(self):
-        assert (self.today16, self.tomorrow16) == \
+        assert (self.today16, self.tomorrow16, False) == \
             guessrangefstr('16:00', locale=locale_de, default_timedelta="1d")
-        assert (self.today16, self.today17) == \
+        assert (self.today16, self.today17, False) == \
             guessrangefstr('16:00 17:00', locale=locale_de, default_timedelta="1d")
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -118,6 +118,7 @@ def test_simple(runner):
     assert not result.exception
 
     result = runner.invoke(main_khal)
+    print(result.output)
     assert 'myevent' in result.output
     assert '18:00' in result.output
     # test show_all_days default value

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -244,7 +244,10 @@ class TestCollection(object):
 
     def test_newevent(self, coll_vdirs):
         coll, vdirs = coll_vdirs
-        event = khal.aux.new_event(dtstart=aday, timezone=aux.BERLIN)
+        bday = datetime.combine(aday, time.min)
+        anend = bday + timedelta(hours=1)
+        event = khal.aux.new_event(dtstart=bday, dtend=anend, summary="hi", timezone=aux.BERLIN,
+                                   locale=aux.locale)
         event = coll.new_event(event.to_ical(), coll.default_calendar_name)
         assert event.allday is False
 


### PR DESCRIPTION
I've created a new interactive command called `edit`, it works completely in
the command line using just prompts, this will close #407, and I believe it solves #49.

This command accepts a search string, and then loops through each event and
asks if the user wants to edit it. If so the user chooses an aspect (eg title),
enters a new value and it is saved. events can also be deleted.

In the future future it would be good to add command line options and a batch
mode, this would enable other commands to edit events. Of course we would need
a way to be specific.