### PR TITLE
change locales in tests to uppercase "UTF-8"

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -23,3 +23,4 @@ Laurent Arnoud - laurent [at] spkdev [dot] net - http://spkdev.net/
 Julian Mehne
 Stephan Weller
 Max Voit - max.voit+dvkh [at] with-eyes [dot] net
+Troy Sankey - sankeytms [at] gmail [dot] com

--- a/tests/cal_display_test.py
+++ b/tests/cal_display_test.py
@@ -139,7 +139,7 @@ example_de = [
 
 
 def test_vertical_month():
-    locale.setlocale(locale.LC_ALL, 'en_US.utf-8')
+    locale.setlocale(locale.LC_ALL, 'en_US.UTF-8')
     vert_str = vertical_month(month=12, year=2011,
                               today=datetime.date(2011, 12, 12))
     assert vert_str == example1
@@ -158,7 +158,7 @@ def test_vertical_month():
 
 def test_vertical_month_unicode():
     try:
-        locale.setlocale(locale.LC_ALL, 'de_DE.utf-8')
+        locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
     except locale.Error as error:
         if str(error) == 'unsupported locale setting':
             pytest.xfail(


### PR DESCRIPTION
Some systems (e.g. Guix) don't seem to respect lowercase aliases for locales.

This addresses one test failure (see #466).