### PR TITLE
Fix typo in usage

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -40,7 +40,7 @@ Several options are common to almost all of :program:`khal`'s commands
 
 .. option:: -d CALENDAR
 
-        Specifiy a calendar which will be disregarded for this run, can be used
+        Specify a calendar which will be disregarded for this run, can be used
         several times.
 
 .. option:: --color/--no-color


### PR DESCRIPTION
Lintian complains about it, because these docs are source for generating man page:
```
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz Specifiy Specify
N: 
N:    Lintian found a spelling error in the manpage. Lintian has a list of
N:    common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:    
N:    If the string containing the spelling error is translated with the help
N:    of gettext (with the help of po4a, for example) or a similar tool,
N:    please fix the error in the translations as well as the English text to
N:    avoid making the translations fuzzy. With gettext, for example, this
N:    means you should also fix the spelling mistake in the corresponding
N:    msgids in the *.po files.
N:    
N:    Severity: minor, Certainty: possible
N:    
N:    Check: manpages, Type: binary
```