### PR TITLE
Allow to pass arguments to sqlite3.connect

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -160,7 +160,7 @@ def global_options(f):
     return config(verbose(color(version(f))))
 
 
-def build_collection(conf, selection):
+def build_collection(conf, selection, **kwargs):
     """build and return a khalendar.CalendarCollection from the configuration"""
     try:
         props = dict()
@@ -182,6 +182,7 @@ def build_collection(conf, selection):
             default_color=conf['highlight_days']['default_color'],
             multiple=conf['highlight_days']['multiple'],
             highlight_event_days=conf['default']['highlight_event_days'],
+            **kwargs,
         )
     except FatalError as error:
         logger.fatal(error)

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -88,16 +88,17 @@ class SQLiteDb(object):
                     None, a place according to the XDG specifications will be
                     chosen
     :type db_path: str or None
+    :param kwargs: These additional parameters will be forwarded to sqlite3.connect
     """
 
-    def __init__(self, calendars, db_path, locale):
+    def __init__(self, calendars, db_path, locale, **kwargs):
         assert db_path is not None
         self.calendars = calendars
         self.db_path = path.expanduser(db_path)
         self._create_dbdir()
         self.locale = locale
         self._at_once = False
-        self.conn = sqlite3.connect(self.db_path)
+        self.conn = sqlite3.connect(self.db_path, **kwargs)
         self.cursor = self.conn.cursor()
         self._create_default_tables()
         self._check_calendars_exists()

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -67,6 +67,7 @@ class CalendarCollection(object):
                  highlight_event_days=0,
                  locale=None,
                  dbpath=None,
+                 **kwargs
                  ):
         assert dbpath is not None
         assert calendars is not None
@@ -95,7 +96,7 @@ class CalendarCollection(object):
         self.highlight_event_days = highlight_event_days
         self._locale = locale
         self._backend = backend.SQLiteDb(
-            calendars=self.names, db_path=dbpath, locale=self._locale)
+            calendars=self.names, db_path=dbpath, locale=self._locale, **kwargs)
         self.update_db()
 
     @property


### PR DESCRIPTION
For instance now in my code, I can do:
`        self.collection = khal.cli.build_collection(self.config, None, check_same_thread=False)`
to prevent exceptions from being read. According to https://github.com/ghaering/pysqlite/issues/106, as long as each thread owns its own connection, it shouldn't be a problem.