### PR TITLE
vdir calendars: use color from config if it's not defined in the vdir

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -26,3 +26,4 @@ Max Voit - max.voit+dvkh [at] with-eyes [dot] net
 Taylor L Money - - http://taylorlmoney.com
 Troy Sankey - sankeytms [at] gmail [dot] com
 Paweł Fertyk - pfertyk [at] openmailbox [dot] org
+Moritz Kobel - moritz [at] kobelnet [dot] ch - http://www.kobelnet.ch

--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -175,7 +175,7 @@ def config_checks(
         if config['calendars'][calendar]['type'] == 'discover':
             vdir = get_all_vdirs(config['calendars'][calendar]['path'])
             vdirs += vdir
-            if len(vdir) >= 1:
+            if len(vdir) >= 1 and 'color' in config['calendars'][calendar]:
                 vdir_colors_from_config[vdir[0]] = config['calendars'][calendar]['color']
             config['calendars'].pop(calendar)
     for vdir in sorted(vdirs):
@@ -186,7 +186,7 @@ def config_checks(
                     }
 
         # get color from config if not defined in vdir
-        if calendar['color'] == None:
+        if calendar['color'] is None and vdir in vdir_colors_from_config:
             calendar['color'] = vdir_colors_from_config[vdir]
 
         name = get_unique_name(vdir, config['calendars'].keys())

--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -170,9 +170,13 @@ def config_checks(
 
     # expand calendars with type = discover
     vdirs = list()
+    vdir_colors_from_config = {}
     for calendar in list(config['calendars'].keys()):
         if config['calendars'][calendar]['type'] == 'discover':
-            vdirs += get_all_vdirs(config['calendars'][calendar]['path'])
+            vdir = get_all_vdirs(config['calendars'][calendar]['path'])
+            vdirs += vdir
+            if len(vdir) >= 1:
+                vdir_colors_from_config[vdir[0]] = config['calendars'][calendar]['color']
             config['calendars'].pop(calendar)
     for vdir in sorted(vdirs):
         calendar = {'path': vdir,
@@ -180,6 +184,11 @@ def config_checks(
                     'type': _get_vdir_type(vdir),
                     'readonly': False
                     }
+
+        # get color from config if not defined in vdir
+        if calendar['color'] == None:
+            calendar['color'] = vdir_colors_from_config[vdir]
+
         name = get_unique_name(vdir, config['calendars'].keys())
         config['calendars'][name] = calendar
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -243,6 +243,7 @@ def test_this_and_prior():
     with pytest.raises(UpdateFailed):
         dbi.update(event_rrule_this_and_prior, href='12345.ics', etag='abcd', calendar=calname)
 
+
 event_rrule_this_and_future_temp = """
 BEGIN:VCALENDAR
 BEGIN:VEVENT
@@ -326,6 +327,7 @@ def test_event_rrule_this_and_future_multi_day_shift():
     assert str(events[0].summary) == 'Arbeit'
     for event in events[1:]:
         assert str(event.summary) == 'Arbeit (lang)'
+
 
 event_rrule_this_and_future_allday_temp = """
 BEGIN:VCALENDAR
@@ -500,6 +502,7 @@ def test_calc_shift_deltas():
         backend.calc_shift_deltas(recuid_this_future)
     assert (timedelta(hours=2), timedelta(hours=4, minutes=30)) == \
         backend.calc_shift_deltas(recuid_this_future_duration)
+
 
 event_a = """BEGIN:VEVENT
 UID:123

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -48,6 +48,7 @@ def runner(tmpdir):
         return runner
     return inner
 
+
 config_template = '''
 [calendars]
 [[one]]

--- a/tests/khalendar_aux_test.py
+++ b/tests/khalendar_aux_test.py
@@ -473,6 +473,7 @@ class TestExpandNoRR(object):
             new_york.localize(datetime(2012, 10, 18, 13, 0)),
         ]
 
+
 vevent_until_notz = """BEGIN:VEVENT
 SUMMARY:until 20. Februar
 DTSTART;TZID=Europe/Berlin:20140203T070000
@@ -664,6 +665,7 @@ class TestSpecial(object):
         assert dtstart[-1] == (berlin.localize(datetime(2014, 12, 3, 9, 30)),
                                berlin.localize(datetime(2014, 12, 3, 10, 30)))
 
+
 simple_rdate = """BEGIN:VEVENT
 SUMMARY:Simple Rdate
 DTSTART;TZID=Europe/Berlin:20131113T190000
@@ -712,6 +714,7 @@ class TestRDate(object):
                             (date(2015, 8, 13), date(2015, 8, 14)),
                             (date(2015, 8, 14), date(2015, 8, 15)),
                             (date(2015, 8, 15), date(2015, 8, 16))]
+
 
 noend_date = """
 BEGIN:VCALENDAR

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -108,6 +108,7 @@ class TestVdirsyncerCompat(object):
             'V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU',
         ))
 
+
 aday = date(2014, 4, 9)
 bday = date(2014, 4, 10)
 

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -142,6 +142,8 @@ def metavdirs(tmpdir):
         '/cal3/public/',
         '/cal3/work/',
         '/cal3/home/',
+        '/cal4/cfgcolor/',
+        '/cal4/dircolor/',
     ]
     for one in dirstructure:
         os.makedirs(tmpdir + one)
@@ -150,6 +152,7 @@ def metavdirs(tmpdir):
         ('/cal1/public/color', 'red'),
         ('/cal1/private/displayname', 'my private calendar'),
         ('/cal1/private/color', '#FF00FF'),
+        ('/cal4/dircolor/color', 'red'),
     ]
     for filename, content in filestructure:
         with open(tmpdir + filename, 'w') as metafile:
@@ -162,7 +165,8 @@ def test_discover(metavdirs):
     vdirs = {vdir[len(path):] for vdir in get_all_vdirs(path+'/*/*')}
     assert vdirs == {
         '/cal1/public', '/cal1/private', '/cal2/public',
-        '/cal3/home', '/cal3/public', '/cal3/work'
+        '/cal3/home', '/cal3/public', '/cal3/work',
+        '/cal4/cfgcolor', '/cal4/dircolor'
     }
 
 
@@ -172,18 +176,26 @@ def test_get_unique_name(metavdirs):
     names = list()
     for vdir in sorted(vdirs):
         names.append(get_unique_name(vdir, names))
-    assert names == ['my private calendar', 'my calendar', 'public', 'home', 'public1', 'work']
+    assert names == ['my private calendar', 'my calendar', 'public', 'home', 'public1', 'work',
+                     'cfgcolor', 'dircolor']
 
 
 def test_config_checks(metavdirs):
     path = metavdirs
-    config = {'calendars': {'default': {'path': path+'/*/*', 'type': 'discover'}},
+    config = {'calendars': {
+                  'default': {'path': path+'/cal[1-3]/*', 'type': 'discover'},
+                  'discover_with_cfgcolor': {'path': path+'/cal4/cfgcolor', 'type': 'discover',
+                                             'color': 'dark blue'},
+                  'discover_with_dircolor': {'path': path+'/cal4/dircolor', 'type': 'discover',
+                                             'color': 'dark blue'},
+              },
               'sqlite': {'path': '/tmp'},
               'locale': {'default_timezone': 'Europe/Berlin', 'local_timezone': 'Europe/Berlin'},
               'default': {'default_calendar': None},
               }
     config_checks(config)
-    for cal in ['home', 'my calendar', 'my private calendar', 'work', 'public1', 'public']:
+    for cal in ['home', 'my calendar', 'my private calendar', 'work', 'public1', 'public',
+                'cfgcolor', 'dircolor']:
         config['calendars'][cal]['path'] = config['calendars'][cal]['path'][len(metavdirs):]
     assert config == {
         'calendars': {
@@ -223,6 +235,18 @@ def test_config_checks(metavdirs):
                 'readonly': False,
                 'type': 'calendar',
             },
+            'cfgcolor': {
+                'color': 'dark blue',
+                'path': '/cal4/cfgcolor',
+                'readonly': False,
+                'type': 'calendar',
+            },
+            'dircolor': {
+                'color': 'red',
+                'path': '/cal4/dircolor',
+                'readonly': False,
+                'type': 'calendar',
+            }
         },
         'default': {'default_calendar': None},
         'locale': {'default_timezone': 'Europe/Berlin', 'local_timezone': 'Europe/Berlin'},

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -440,6 +440,7 @@ def test_description():
             event = _construct_event(data_list.split(), locale=locale_de)
             assert _replace_uid(event).to_ical() == vevent
 
+
 test_set_repeat = _create_testcases(
     # now events where the start date has to be inferred, too
     # today


### PR DESCRIPTION
With the following config, the color setting did not work:

```
[[my_calendar]]
path = ~/.calendars/my_calendar
type = discover
color = dark blue
```

Therefore I modified the code to use the color setting as fallback if there is no color defined in the directory.
