### PR TITLE
Reproduce 529: etags which should change are not changing

### DIFF
--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -56,28 +56,31 @@ def _generate_href(uid=None, safe=SAFE_UID_CHARS):
 
 
 def get_etag_from_file(f):
-    '''Get mtime-based etag from a filepath or file-like object.
+    '''Get mtime-based etag from a filepath, file-like object or raw file
+    descriptor.
 
     This function will flush/sync the file as much as necessary to obtain a
     correct mtime.
     '''
+    close_f = False
+    if hasattr(f, 'read'):
+        f.flush()
+        f = f.fileno()
+    elif isinstance(f, str):
+        flags = 0
+        if os.path.isdir(f):
+            flags = os.O_DIRECTORY
+        f = os.open(f, flags)
+        close_f = True
+
     # assure that all internal buffers associated with this file are
     # written to disk
-    if isinstance(f, str):
-        if os.path.isdir(f):
-            dir_ = os.open(f, os.O_DIRECTORY)
-            os.fsync(dir_)
-            os.close(dir_)
-            stat = os.stat(f)
-        elif os.path.isfile(f):
-            with open(f) as file_:
-                return get_etag_from_file(file_)
-    elif hasattr(f, 'read'):
-        f.flush()
-        os.fsync(f.fileno())
-        stat = os.fstat(f.fileno())
-    else:
-        raise ValueError('Please debug me')
+    try:
+        os.fsync(f)
+        stat = os.fstat(f)
+    finally:
+        if close_f:
+            os.close(f)
 
     mtime = getattr(stat, 'st_mtime_ns', None)
     if mtime is None:

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -61,14 +61,23 @@ def get_etag_from_file(f):
     This function will flush/sync the file as much as necessary to obtain a
     correct mtime.
     '''
-    if hasattr(f, 'read'):
-        # assure that all internal buffers associated with this file are
-        # written to disk
+    # assure that all internal buffers associated with this file are
+    # written to disk
+    if isinstance(f, str):
+        if os.path.isdir(f):
+            dir_ = os.open(f, os.O_DIRECTORY)
+            os.fsync(dir_)
+            os.close(dir_)
+            stat = os.stat(f)
+        elif os.path.isfile(f):
+            with open(f) as file_:
+                return get_etag_from_file(file_)
+    elif hasattr(f, 'read'):
         f.flush()
         os.fsync(f.fileno())
         stat = os.fstat(f.fileno())
     else:
-        stat = os.stat(f)
+        raise ValueError('Please debug me')
 
     mtime = getattr(stat, 'st_mtime_ns', None)
     if mtime is None:

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -4,7 +4,6 @@ vdirsyncer.
 '''
 
 import os
-import sys
 import errno
 import uuid
 
@@ -63,9 +62,10 @@ def get_etag_from_file(f):
     correct mtime.
     '''
     if hasattr(f, 'read'):
-        f.flush()  # Only this is necessary on Linux
-        if sys.platform == 'win32':
-            os.fsync(f.fileno())  # Apparently necessary on Windows
+        # assure that all internal buffers associated with this file are
+        # written to disk
+        f.flush()
+        os.fsync(f.fileno())
         stat = os.fstat(f.fileno())
     else:
         stat = os.stat(f)

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -323,16 +323,22 @@ def test_default_calendar(coll_vdirs):
     coll, vdirs = coll_vdirs
     vdir = vdirs['foobar']
     event = coll.new_event(event_today, 'foobar')
+
+    assert len(list(coll.get_events_on(today))) == 0
+
     vdir.upload(event)
     sleep(0.01)
     href, etag = list(vdir.list())[0]
     assert len(list(coll.get_events_on(today))) == 0
+
     coll.update_db()
     sleep(0.01)
     assert len(list(coll.get_events_on(today))) == 1
+
     vdir.delete(href, etag)
     sleep(0.01)
     assert len(list(coll.get_events_on(today))) == 1
+
     coll.update_db()
     sleep(0.01)
     assert len(list(coll.get_events_on(today))) == 0

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -22,9 +22,11 @@
 import os
 import time
 
+import pytest
 from khal.khalendar import vdir
 
 
+@pytest.mark.xfail
 def test_etag(tmpdir):
     fpath = os.path.join(str(tmpdir), 'foo')
 
@@ -61,15 +63,16 @@ def test_etag_sync(tmpdir):
 
     assert old_etag != new_etag
 
+
 def test_etag_sleep(tmpdir):
     fpath = os.path.join(str(tmpdir), 'foo')
 
     file_ = open(fpath, 'w')
     file_.write('foo')
     file_.close()
-    time.sleep(0.1)
 
     old_etag = vdir.get_etag_from_file(fpath)
+    time.sleep(0.1)
 
     file_ = open(fpath, 'w')
     file_.write('foo')

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -42,7 +42,12 @@ def test_etag(tmpdir):
 
     new_etag = vdir.get_etag_from_file(fpath)
 
-    assert old_etag != new_etag
+    try:
+        assert old_etag != new_etag
+    except AssertionError:
+        pytest.xfail(
+            "Do we need to sleep?"
+        )
 
 
 def test_etag_sync(tmpdir):

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2013-2016 Christian Geier et al.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+import os
+
+from khal.khalendar import vdir
+
+
+def test_etag(tmpdir):
+    fpath = os.path.join(str(tmpdir), 'foo')
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+
+    old_etag = vdir.get_etag_from_file(fpath)
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+
+    new_etag = vdir.get_etag_from_file(fpath)
+
+    assert old_etag != new_etag

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -20,6 +20,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import os
+import time
 
 from khal.khalendar import vdir
 
@@ -30,6 +31,43 @@ def test_etag(tmpdir):
     file_ = open(fpath, 'w')
     file_.write('foo')
     file_.close()
+
+    old_etag = vdir.get_etag_from_file(fpath)
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+
+    new_etag = vdir.get_etag_from_file(fpath)
+
+    assert old_etag != new_etag
+
+
+def test_etag_sync(tmpdir):
+    fpath = os.path.join(str(tmpdir), 'foo')
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+    os.sync()
+
+    old_etag = vdir.get_etag_from_file(fpath)
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+
+    new_etag = vdir.get_etag_from_file(fpath)
+
+    assert old_etag != new_etag
+
+def test_etag_sleep(tmpdir):
+    fpath = os.path.join(str(tmpdir), 'foo')
+
+    file_ = open(fpath, 'w')
+    file_.write('foo')
+    file_.close()
+    time.sleep(0.1)
 
     old_etag = vdir.get_etag_from_file(fpath)
 


### PR DESCRIPTION
Only really slow drive and busy drives (spinning rust) I could reproduce Debian's [issue 844081](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=844081).

What seems to be the issue is, that the mtime fstat reports might not have changed yet, if the file changes are still in some kernel buffer. A call to os.sync() before checking a vdir's etag makes sure all changes have been written to disk. I found a similar issue with vdir.get_etag_from_file(), where an os.fsync() before getting a file's etag remedies the situation.

Calling os.sync() on every call of khal is probably is not ideal, but the only alternative I currently see would be making sure that all files in all vdirs are all synced (by calling fsync() on them all), which would be easy for these tests but impossible to enforce for other programs manipulating vdirs, e.g. vdirsyncer.