### PR TITLE
Python 3.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - 3.3
     - 3.4
     - 3.5
+    - 3.6
 
 env:
     - BUILD=tests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -30,6 +30,7 @@ not released yet
 * `import` can now import multiple files at once (Christian Geier)
 * configuration file path $XDG_CONFIG_HOME/khal/config is now supported and
   $XDG_CONFIG_HOME/khal/khal.conf deprecated
+* python 3.6 is now officially supported
 
 ikhal
 -----

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Utilities",
         "Topic :: Communications",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py33, py34, py35}-{tests, tests-negtz, style}
+envlist = {py33, py34, py35, py36}-{tests, tests-negtz, style}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Nothing fancy, just run tests with py36 to make sure we don't break anything.