### PR TITLE
Remove superfluous space from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py33, py34, py35, py36}-{tests, tests-negtz, style}
+envlist = {py33,py34,py35,py36}-{tests,tests-negtz,style}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
This space made environment generation bugging (leading space), and running `tox` (with no env specified) failed (due to a path being generated with the leading space in it).