### PR TITLE
Tweak sleep_time to be as precise as possible

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,7 +70,7 @@ def sleep_time(tmpdir_factory):
         return getattr(stat, 'st_mtime_ns', stat.st_mtime)
 
     i = 0.00001
-    while True:
+    while i < 100:
         # Measure three times to avoid things like 12::18:11.9994 [mis]passing
         first = touch_and_mtime()
         sleep(i)
@@ -81,3 +81,9 @@ def sleep_time(tmpdir_factory):
         if first != second != third:
             return i * 1.1
         i = i * 10
+
+    # This should never happen, but oh, well:
+    raise Exception(
+        'Filesystem does not seem to save modified times of files. \n'
+        'Cannot run tests that depend on this.'
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,8 @@ def never_echo_bytes(monkeypatch):
 @pytest.fixture(scope='session')
 def sleep_time(tmpdir_factory):
     """
+    Returns the filesystem's mtime precision
+
     Returns how long we need to sleep for the filesystem's mtime precision to
     pick up differences.
 
@@ -67,10 +69,15 @@ def sleep_time(tmpdir_factory):
         stat = os.stat(str(tmpfile))
         return getattr(stat, 'st_mtime_ns', stat.st_mtime)
 
-    first = touch_and_mtime()
-    sleep(0.1)
-    second = touch_and_mtime()
+    i = 0.00001
+    while True:
+        # Measure three times to avoid things like 12::18:11.9994 [mis]passing
+        first = touch_and_mtime()
+        sleep(i)
+        second = touch_and_mtime()
+        sleep(i)
+        third = touch_and_mtime()
 
-    if first < second:
-        return 0.01
-    return 1.1
+        if first != second != third:
+            return i * 1.1
+        i = i * 10


### PR DESCRIPTION
Tweak sleep_time to be as precise as possible, and also account for possible rounding error when our sleep is equal to the maximum precision (basically, for rounding in our favour).

See [this discussion](https://github.com/pimutils/khal/pull/575#pullrequestreview-22009618).