### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/source/configspec.rst
+++ b/doc/source/configspec.rst
@@ -513,7 +513,7 @@ when using khal and ikhal.
 .. object:: agenda_day_format
 
     
-    Specifies how each *day header* is formated.
+    Specifies how each *day header* is formatted.
 
       :type: string
       :default: {bold}{name}, {date-long}{reset}
@@ -523,11 +523,11 @@ when using khal and ikhal.
 .. object:: agenda_event_format
 
     
-    Default formating for events used when the user asks for all events in a
+    Default formatting for events used when the user asks for all events in a
     given time range, used for :command:`list`, :command:`calendar` and in
-    :command:`interactive` (ikhal). Please note, that any color styling will be
-    ignored in `ikhal`, where events will always be shown in the color of the
-    calendar they belong to.
+    :command:`interactive` (ikhal). Please note, that any color styling will
+    be ignored in `ikhal`, where events will always be shown in the color of
+    the calendar they belong to.
     The syntax is the same as for :option:`--format`.
 
       :type: string
@@ -563,10 +563,10 @@ when using khal and ikhal.
 .. object:: event_format
 
     
-    Default formating for events used when the start- and end-date are not clear
-    through context, e.g. for :command:`search`, used almost everywhere but
-    :command:`list` and :command:`calendar`. It is therefore probably a sensible
-    choice to include the start- and end-date.
+    Default formatting for events used when the start- and end-date are not
+    clear through context, e.g. for :command:`search`, used almost everywhere
+    but :command:`list` and :command:`calendar`. It is therefore probably a
+    sensible choice to include the start- and end-date.
     The syntax is the same as for :option:`--format`.
 
       :type: string
@@ -599,10 +599,10 @@ when using khal and ikhal.
     
     Whether to show a visible frame (with *box drawing* characters) around some
     (groups of) elements or not. There are currently several different frame
-    options available, that should visually differentiate wether an element is
-    in focus or not. Some of them will probably be removed in future releases of
-    khal, so please try them out and give feedback on which style you prefer (the
-    color of all variants can be defined in the color themes).
+    options available, that should visually differentiate whether an element
+    is in focus or not. Some of them will probably be removed in future
+    releases of khal, so please try them out and give feedback on which style
+    you prefer (the color of all variants can be defined in the color themes).
 
       :type: option, allowed values are *False*, *width*, *color* and *top*
       :default: False

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -55,9 +55,9 @@ Several options are common to almost all of :program:`khal`'s commands
 .. option:: --format FORMAT
 
    For all of khal's commands that print events, the formatting of that event
-   can be specfied with this option.  ``FORMAT`` is a template
+   can be specified with this option.  ``FORMAT`` is a template
    string, in which identifiers delimited by curly braces (`{}`) will be
-   expanded to an event's properties.  ``FORMAT`` supports all formating
+   expanded to an event's properties.  ``FORMAT`` supports all formatting
    options offered by python's `str.format()`_ (as it is used internally).
    The available template options are:
 

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -232,17 +232,17 @@ theme = option('dark', 'light', default='dark')
 
 # Whether to show a visible frame (with *box drawing* characters) around some
 # (groups of) elements or not. There are currently several different frame
-# options available, that should visually differentiate wether an element is
+# options available, that should visually differentiate whether an element is
 # in focus or not. Some of them will probably be removed in future releases of
-# khal, so please try them out and give feedback on which style you prefer (the
-# color of all variants can be defined in the color themes).
+# khal, so please try them out and give feedback on which style you prefer
+# (the color of all variants can be defined in the color themes).
 frame = option('False', 'width', 'color', 'top', default='False')
 
 # Whether to use bold text for light colors or not. Non-bold light colors may
 # not work on all terminals but allow using light background colors.
 bold_for_light_color = boolean(default=True)
 
-# Default formating for events used when the user asks for all events in a
+# Default formatting for events used when the user asks for all events in a
 # given time range, used for :command:`list`, :command:`calendar` and in
 # :command:`interactive` (ikhal). Please note, that any color styling will be
 # ignored in `ikhal`, where events will always be shown in the color of the
@@ -250,13 +250,13 @@ bold_for_light_color = boolean(default=True)
 # The syntax is the same as for :option:`--format`.
 agenda_event_format = string(default='{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{description-separator}{description}{reset}')
 
-# Specifies how each *day header* is formated.
+# Specifies how each *day header* is formatted.
 agenda_day_format = string(default='{bold}{name}, {date-long}{reset}')
 
-# Default formating for events used when the start- and end-date are not clear
-# through context, e.g. for :command:`search`, used almost everywhere but
-# :command:`list` and :command:`calendar`. It is therefore probably a sensible
-# choice to include the start- and end-date.
+# Default formatting for events used when the start- and end-date are not
+# clear through context, e.g. for :command:`search`, used almost everywhere
+# but :command:`list` and :command:`calendar`. It is therefore probably a
+# sensible choice to include the start- and end-date.
 # The syntax is the same as for :option:`--format`.
 event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{description-separator}{description}{reset}')
 


### PR DESCRIPTION
Fixing warnings from pedantic lintian:

```
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz specfied specified
N:
N:    Lintian found a spelling error in the manpage. Lintian has a list of
N:    common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
N:
N:    If the string containing the spelling error is translated with the help
N:    of gettext (with the help of po4a, for example) or a similar tool,
N:    please fix the error in the translations as well as the English text to
N:    avoid making the translations fuzzy. With gettext, for example, this
N:    means you should also fix the spelling mistake in the corresponding
N:    msgids in the *.po files.
N:
N:    Severity: minor, Certainty: possible
N:
N:    Check: manpages, Type: binary
N:
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz formating formatting
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz appropriatly appropriately
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz formated formatted
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz formating formatting
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz formating formatting
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz wether whether
I: khal: spelling-error-in-manpage usr/share/man/man1/khal.1.gz containg containing
```