### PR TITLE
More pythons and CI stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - 3.4
     - 3.5
     - 3.6
+    - 3.7-dev
 
 env:
     - BUILD=tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ python:
     - 3.7-dev
 
 env:
-    - BUILD=tests
-    - BUILD=tests-negtz
+    - BUILD=py
+    - BUILD=negtz
 
 matrix:
     include:
@@ -26,4 +26,4 @@ install:
         - "pip install tox"
 
 script:
-    - "tox -e py-$BUILD"
+    - "tox -e $BUILD"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,11 @@ python:
 env:
     - BUILD=tests
     - BUILD=tests-negtz
-    - BUILD=style
+
+matrix:
+    include:
+      - python: 3.6
+        env: BUILD=style
 
 addons:
     apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ matrix:
     include:
       - python: 3.6
         env: BUILD=style
+      - python: 3.6
+        env: BUILD=docs
 
 addons:
     apt:

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,11 @@ commands =
     py.test --cov khal {posargs}
     codecov -e TOXENV
 
-[testenv:py-tests-negtz]
+[testenv:negtz]
 setenv =
     TZ = America/Argentina/Buenos_Aires
 
-[testenv:py-style]
+[testenv:style]
 skip_install=True
 whitelist_externals = sh
 deps = flake8

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,13 @@ commands =
     flake8
     sh -c '! grep -ri seperat */*'
 
+[testenv:docs]
+whitelist_externals = make
+commands =
+  pip install -r doc/requirements.txt
+  make -C doc html
+  make -C doc man
+
 [flake8]
 max-line-length = 100
 exclude=.tox,examples,doc


### PR DESCRIPTION
Test out ~pypy3~ and python3.7 (the latter won't make CI fail, it's mostly informative so we keep an eye on forward compatibility).

Also make sure docs build on CI so we never merge broken docs into master.

Finally, reduce the CI matrix a bit, because otherwise with these changes it would be huge, while adding little value.

**EDIT:** Nope, khal does not seem to work on pypy3. [CI results](https://travis-ci.org/hobarrera/khal/jobs/209199316)