### PR TITLE
Fix viewing/editing logic in ikhal

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -29,3 +29,4 @@ Mart Lubbers - mart [at] martlubbers [dot] net
 Paweł Fertyk - pfertyk [at] openmailbox [dot] org
 Moritz Kobel - moritz [at] kobelnet [dot] ch - http://www.kobelnet.ch
 Guilhem Saurel - guilhem [at] saurel [dot] me - https://saurel.me
+Stefan Siegel - ssiegel [at] sdas [dot] net

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -913,12 +913,12 @@ class EventColumn(urwid.WidgetWrap):
                 if self.delete_status(self.focus_event.recuid):
                     self.pane.window.alert(('alert', 'This event is marked as deleted'))
                 self.edit(self.focus_event.event)
+            elif key in self._conf['keybindings']['external_edit']:
+                self.edit(self.focus_event.event, external_edit=True)
             elif key in self._conf['keybindings']['view'] or \
                     self._conf['view']['event_view_always_visible']:
                 self._eventshown = self.focus_event.recuid
                 self.view(self.focus_event.event)
-            elif key in self._conf['keybindings']['external_edit']:
-                self.edit(self.focus_event.event, external_edit=True)
         return rval
 
     def render(self, a, focus):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -911,7 +911,7 @@ class EventColumn(urwid.WidgetWrap):
                     prev_shown == self.focus_event.recuid:
                 # the event in focus is already viewed -> edit
                 if self.delete_status(self.focus_event.recuid):
-                    self.pane.window.alert(('light red', 'This event is marked as deleted'))
+                    self.pane.window.alert(('alert', 'This event is marked as deleted'))
                 self.edit(self.focus_event.event)
             elif key in self._conf['keybindings']['view'] or \
                     self._conf['view']['event_view_always_visible']:


### PR DESCRIPTION
Test case for the unexpected behavior which is fixed by this commit:

Show the first event of some day, then
- with event_view_always_visible = False:
  press Escape, Up, Down, Enter
- with event_view_always_visible = True:
  press Up, Down

The expected result is to just view the event, but previously the edit form was opened.