### PR TITLE
Add solarized light theme

### DIFF
--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -228,7 +228,7 @@ event_view_always_visible = boolean(default=False)
 #
 # __ http://urwid.org/manual/displayattributes.html
 # .. _github: # https://github.com/pimutils/khal/issues
-theme = option('dark', 'light', default='dark')
+theme = option('dark', 'light', 'solarized_light', default='dark')
 
 # Whether to show a visible frame (with *box drawing* characters) around some
 # (groups of) elements or not. There are currently several different frame

--- a/khal/ui/colors.py
+++ b/khal/ui/colors.py
@@ -92,3 +92,40 @@ light = [
     ('editcp', 'black', 'light gray', 'standout'),
     ('popupbg', 'white', 'black', 'bold'),
 ]
+
+solarized_light = [
+    ('header', 'black', 'white'),
+    ('footer', 'black', 'white'),
+    ('line header', 'black', 'white', 'bold'),
+    ('bright', 'dark blue', 'white', ('bold', 'standout')),
+    ('list', 'black', 'white'),
+    ('list focused', 'white', 'light blue', 'bold'),
+    ('edit', 'black', 'white'),
+    ('edit focused', 'white', 'light blue', 'bold'),
+    ('button', 'black', 'dark cyan'),
+    ('button focused', 'white', 'light blue', 'bold'),
+
+    ('reveal focus', 'black', 'dark cyan', 'standout'),
+    ('today focus', 'white', 'dark cyan', 'standout'),
+    ('today', 'black', 'light gray', 'dark cyan'),
+
+    ('date', '', 'white'),
+    ('date focused', 'white', 'dark gray', ('bold', 'standout')),
+    ('date selected', 'dark gray', 'light cyan'),
+
+    ('dayname', 'dark gray', 'white'),
+    ('monthname', 'dark gray', 'white'),
+    ('weeknumber_right', 'dark gray', 'white'),
+    ('edit', 'white', 'dark blue'),
+    ('alert', 'white', 'dark red'),
+    ('mark', 'white', 'dark green'),
+    ('frame', 'dark gray', 'white'),
+    ('frame focus', 'light red', 'white'),
+    ('frame focus color', 'dark blue', 'white'),
+    ('frame focus top', 'dark magenta', 'white'),
+
+    ('editfc', 'white', 'dark blue', 'bold'),
+    ('editbx', 'light gray', 'dark blue'),
+    ('editcp', 'black', 'light gray', 'standout'),
+    ('popupbg', 'white', 'black', 'bold'),
+]


### PR DESCRIPTION
I had some problems with the regular light theme when using the solarized light color scheme in my urxvt terminal. I therefore modded it a bit and created a solarized light theme. The entries I changed are 'today', 'date' and 'date selected'. Every other entry is the same. 

Regular light theme in my terminal:
![screenshot_2017-03-26_12-30-52](https://cloud.githubusercontent.com/assets/19759098/24330593/013fd57c-1222-11e7-8df0-47086b40b029.png)

Solarized light theme in my terminal:
![ikhal_solarized_light](https://cloud.githubusercontent.com/assets/19759098/24330595/0baeb834-1222-11e7-8d2d-41fec3a4e045.png)

