### PR TITLE
Integrate sync into config wizard

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ not released
 * UPDATED REQUIREMENT pytz is now required >= 2018.7
 * FIX if a `discover` collection is set to "readonly", discovered collections
   will now inherit the readonly property
+* NEW the `configure` command can now set up vdirsyncer
 
 0.10.5
 ======

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -167,7 +167,7 @@ def get_vdirs_from_vdirsyncer_config():
 
 def find_vdir():
     """Use one or more existing vdirs on the system.
-    
+
     Tries to get data from vdirsyncer if it's installed and configured, and
     asks user to confirm it. If not, prompt the user for the path to a single
     vdir.
@@ -237,7 +237,7 @@ password = {password}
 
 def vdirsyncer_config_path():
     """Find where vdirsyncer will look for it's config.
-    
+
     There may or may not already be a file at the returned path.
     """
     fname = environ.get('VDIRSYNCER_CONFIG', None)
@@ -255,7 +255,6 @@ def get_available_pairno():
     """
     try:
         from vdirsyncer.cli import config
-        from vdirsyncer.exceptions import UserError
     except ImportError:
         raise FatalError("vdirsyncer config exists, but couldn't import vdirsyncer.")
     vdir_config = config.load_config()
@@ -263,6 +262,7 @@ def get_available_pairno():
     while 'khal_pair_{}'.format(pairno) in vdir_config.pairs:
         pairno += 1
     return pairno
+
 
 def create_synced_vdir():
     """Create a new vdir, and set up vdirsyncer to sync it.

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -21,14 +21,13 @@
 #
 
 import datetime as dt
+import json
 import logging
 from functools import partial
-import json
 from itertools import zip_longest
-from os.path import (expanduser, expandvars, join, normpath, exists, isdir,
-                     dirname)
-from os import makedirs, environ
-from os.path import expanduser, expandvars, join, normpath, exists, isdir
+from os import environ, makedirs
+from os.path import (dirname, exists, expanduser, expandvars, isdir, join,
+                     normpath)
 from subprocess import call
 
 import xdg
@@ -177,9 +176,9 @@ def find_vdir():
     print("The following calendars were found:")
     synced_vdirs = get_vdirs_from_vdirsyncer_config()
     if synced_vdirs:
-        print("Found {} calendars from vdirsyncer".format(len(synced_vdirs)))
+        print(f"Found {len(synced_vdirs)} calendars from vdirsyncer")
         for name, path, _ in synced_vdirs:
-            print('  {}: {}'.format(name, compressuser(path)))
+            print(f'  {name}: {compressuser(path)}')
         if confirm("Use these calendars for khal?", default=True):
             return synced_vdirs
 
@@ -261,7 +260,7 @@ def get_available_pairno():
         raise FatalError("vdirsyncer config exists, but couldn't import vdirsyncer.")
     vdir_config = config.load_config()
     pairno = 1
-    while 'khal_pair_{}'.format(pairno) in vdir_config.pairs:
+    while f'khal_pair_{pairno}' in vdir_config.pairs:
         pairno += 1
     return pairno
 
@@ -330,7 +329,7 @@ def choose_vdir_calendar():
     ]
     validate = partial(validate_int, min_value=0, max_value=2)
     for i, (desc, func) in enumerate(choices):
-        print('[{}] {}'.format(i, desc))
+        print(f'[{i}] {desc}')
     choice_no = prompt("Please choose one of the above options",
                        value_proc=validate)
     return choices[choice_no][1]()

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -324,7 +324,8 @@ def choose_vdir_calendar():
     choices = [
         ("Create a new calendar on this computer", create_vdir),
         ("Use a calendar already on this computer (vdir format)", find_vdir),
-        ("Sync a calendar from the internet (CalDAV format)", create_synced_vdir),
+        ("Sync a calendar from the internet (CalDAV format, requires vdirsyncer)",
+         create_synced_vdir),
     ]
     validate = partial(validate_int, min_value=0, max_value=2)
     for i, (desc, func) in enumerate(choices):

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -125,7 +125,7 @@ def choose_time_format():
 def choose_default_calendar(vdirs):
     names = [name for name, _, _ in sorted(vdirs or ())]
     print("Which calendar do you want as a default calendar?")
-    print("(The default calendar is used, when no calendar is specified.)")
+    print("(The default calendar is used when no calendar is specified.)")
     print(f"Configured calendars: {', '.join(names)}")
     default_calendar = prompt(
         "Please type one of the above options",
@@ -146,7 +146,7 @@ def get_vdirs_from_vdirsyncer_config():
     try:
         vdir_config = config.load_config()
     except UserError as error:
-        print("Sorry, trying to load vdirsyncer config failed with the following "
+        print("Sorry, loading vdirsyncer config failed with the following "
               "error message:")
         print(error)
         return None
@@ -185,6 +185,7 @@ def find_vdir():
     vdir_path = prompt("Enter the path to a vdir calendar")
     vdir_path = normpath(expanduser(expandvars(vdir_path)))
     return [('private', vdir_path, 'calendar')]
+
 
 def create_vdir(names=None):
     """create a new vdir, make sure the name doesn't collide with existing names
@@ -328,7 +329,7 @@ def choose_vdir_calendar():
          create_synced_vdir),
     ]
     validate = partial(validate_int, min_value=0, max_value=2)
-    for i, (desc, func) in enumerate(choices):
+    for i, (desc, _func) in enumerate(choices):
         print(f'[{i}] {desc}')
     choice_no = prompt("Please choose one of the above options",
                        value_proc=validate)

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -376,7 +376,6 @@ def configwizard():
         vdirs = choose_vdir_calendar()
     except OSError as error:
         raise FatalError(error)
-    print()
 
     if not vdirs:
         print("\nWARNING: no vdir configured, khal will not be usable like this!\n")

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -159,7 +159,7 @@ def get_vdirs_from_vdirsyncer_config():
             path += '*'
             vdirs.append((storage['instance_name'], path, 'discover'))
     if vdirs == []:
-        print("No calendards found from vdirsyncer.")
+        print("No calendars found from vdirsyncer.")
         return None
     else:
         return vdirs

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -372,7 +372,10 @@ def configwizard():
     print()
     timeformat = choose_time_format()
     print()
-    vdirs = choose_vdir_calendar()
+    try:
+        vdirs = choose_vdir_calendar()
+    except OSError as error:
+        raise FatalError(error)
     print()
 
     if not vdirs:

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -126,7 +126,7 @@ def choose_time_format():
 def choose_default_calendar(vdirs):
     names = [name for name, _, _ in sorted(vdirs or ())]
     print("Which calendar do you want as a default calendar?")
-    print("(The default calendar is specified, when no calendar is specified.)")
+    print("(The default calendar is used, when no calendar is specified.)")
     print(f"Configured calendars: {', '.join(names)}")
     default_calendar = prompt(
         "Please type one of the above options",
@@ -174,7 +174,7 @@ def find_vdir():
     asks user to confirm it. If not, prompt the user for the path to a single
     vdir.
     """
-    print("The following collections were found:")
+    print("The following calendars were found:")
     synced_vdirs = get_vdirs_from_vdirsyncer_config()
     if synced_vdirs:
         print("Found {} calendars from vdirsyncer".format(len(synced_vdirs)))

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -166,6 +166,12 @@ def get_vdirs_from_vdirsyncer_config():
 
 
 def find_vdir():
+    """Use one or more existing vdirs on the system.
+    
+    Tries to get data from vdirsyncer if it's installed and configured, and
+    asks user to confirm it. If not, prompt the user for the path to a single
+    vdir.
+    """
     print("The following collections were found:")
     synced_vdirs = get_vdirs_from_vdirsyncer_config()
     if synced_vdirs:
@@ -230,6 +236,10 @@ password = {password}
 
 
 def vdirsyncer_config_path():
+    """Find where vdirsyncer will look for it's config.
+    
+    There may or may not already be a file at the returned path.
+    """
     fname = environ.get('VDIRSYNCER_CONFIG', None)
     if fname is None:
         fname = normpath(expanduser('~/.vdirsyncer/config'))
@@ -291,6 +301,7 @@ def create_synced_vdir():
 
 
 def start_syncing():
+    """Run vdirsyncer to sync the newly created vdir with the remote."""
     print("Syncing calendar...")
     try:
         exit_code = call(['vdirsyncer', 'discover'])
@@ -309,6 +320,7 @@ def start_syncing():
 
 
 def choose_vdir_calendar():
+    """query the user for their preferred calendar source"""
     choices = [
         ("Create a new calendar on this computer", create_vdir),
         ("Use a calendar already on this computer (vdir format)", find_vdir),

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -38,6 +38,15 @@ from .settings import find_configuration_file
 logger = logging.getLogger('khal')
 
 
+def compressuser(path):
+    """Abbreviate home directory to '~', for presenting a path."""
+    home = normpath(expanduser('~'))
+    path = normpath(path)
+    if path.startswith(home):
+        path = '~' + path[len(home):]
+    return path
+
+
 def validate_int(input, min_value, max_value):
     try:
         number = int(input)
@@ -160,9 +169,9 @@ def find_vdir():
     print("The following collections were found:")
     synced_vdirs = get_vdirs_from_vdirsyncer_config()
     if synced_vdirs:
-        print("Found {} calendars from vdirsyncer")
+        print("Found {} calendars from vdirsyncer".format(len(synced_vdirs)))
         for name, path, _ in synced_vdirs:
-            print('  {}: {}'.format(name, path))
+            print('  {}: {}'.format(name, compressuser(path)))
         if confirm("Use these calendars for khal?", default=True):
             return synced_vdirs
 
@@ -316,7 +325,7 @@ def create_config(vdirs, dateformat, timeformat, default_calendar=None):
 def configwizard():
     config_file = find_configuration_file()
     if config_file is not None:
-        logger.fatal(f"Found an existing config file at {config_file}.")
+        logger.fatal(f"Found an existing config file at {compressuser(config_file)}.")
         logger.fatal(
             "If you want to create a new configuration file, "
             "please remove the old one first. Exiting.")
@@ -343,7 +352,7 @@ def configwizard():
     )
     config_path = join(xdg.BaseDirectory.xdg_config_home, 'khal', 'config')
     if not confirm(
-            f"Do you want to write the config to {config_path}? "
+            f"Do you want to write the config to {compressuser(config_path)}? "
             "(Choosing `No` will abort)", default=True):
         raise FatalError('User aborted...')
     config_dir = join(xdg.BaseDirectory.xdg_config_home, 'khal')
@@ -352,12 +361,12 @@ def configwizard():
             makedirs(config_dir)
         except OSError as error:
             print(
-                f"Could not write config file at {config_dir} because of "
+                f"Could not write config file at {compressuser(config_dir)} because of "
                 f"{error}. Aborting"
             )
             raise FatalError(error)
         else:
-            print(f'created directory {config_dir}')
+            print(f"created directory {compressuser(config_dir)}")
     with open(config_path, 'w') as config_file:
         config_file.write(config)
-    print(f"Successfully wrote configuration to {config_path}")
+    print(f"Successfully wrote configuration to {compressuser(config_path)}")

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -25,6 +25,8 @@ import logging
 from functools import partial
 import json
 from itertools import zip_longest
+from os.path import (expanduser, expandvars, join, normpath, exists, isdir,
+    dirname)
 from os import makedirs, environ
 from os.path import expanduser, expandvars, join, normpath, exists, isdir
 from subprocess import call
@@ -290,7 +292,7 @@ def create_synced_vdir():
             f.write(VDS_CONFIG_START)
 
         f.write(VDS_CONFIG_TEMPLATE.format(
-            local_path=json.dumps(path),
+            local_path=json.dumps(dirname(path)),
             url=json.dumps(caldav_url),
             username=json.dumps(username),
             password=json.dumps(password),

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -307,16 +307,15 @@ def start_syncing():
         exit_code = call(['vdirsyncer', 'discover'])
     except FileNotFoundError:
         print("Could not find vdirsyncer - please set it up manually")
-        exit_code = 1
     else:
         if exit_code == 0:
             exit_code = call(['vdirsyncer', 'sync'])
         if exit_code != 0:
             print("vdirsyncer failed - please set up sync manually")
 
-    if exit_code == 0:
-        # TODO: add to cron
-        pass
+    # Add code here to check platform and automatically set up cron or similar
+    print("Please set up your system to run 'vdirsyncer sync' periodically, "
+          "using cron or similar mechanisms.")
 
 
 def choose_vdir_calendar():

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -167,6 +167,7 @@ def find_vdir():
             return synced_vdirs
 
     vdir_path = prompt("Enter the path to a vdir calendar")
+    vdir_path = normpath(expanduser(expandvars(vdir_path)))
     return [('private', vdir_path, 'calendar')]
 
 def create_vdir(names=None):

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -26,7 +26,7 @@ from functools import partial
 import json
 from itertools import zip_longest
 from os.path import (expanduser, expandvars, join, normpath, exists, isdir,
-    dirname)
+                     dirname)
 from os import makedirs, environ
 from os.path import expanduser, expandvars, join, normpath, exists, isdir
 from subprocess import call


### PR DESCRIPTION
This follows on from #615, to make first-time setup more user friendly. It isn't 100% where I want it to be, but it shows how I think this should work. Instead of y/n questions, we present the user with another menu of options:

```
[0] Create a new calendar on this computer
[1] Use a calendar already on this computer (vdir format)
[2] Sync a calendar from the internet (CalDAV format)
```

Selecting 0 creates a new calendar, ignoring vdirsycner. Selecting 1 attempts to find vdirsyncer config to identify where a calendar might be; the user can reject this and enter a location manually if they prefer. Selecting 2 creates a new calendar and tries to write vdirsyncer config to sync it, prompting the user to enter details of a caldav server.

Things that aren't right yet:

a. I've currently assumed that khal's and vdirsyncer's config point to the same calendar directory, but looking at the config on my machine, I think vds actually points one level above, at a directory containing a collection of calendars. Is this correct?
b. When setting up vdirsyncer (for option 2), I'd like to set it up to run regularly, e.g. adding it to cron on Linux. Do you know of any good tools to do this kind of thing cross-platform?