### PR TITLE
Import from stdid if no filename is provided

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,8 @@ unreleased
 * FIX don't crash on updated vcards
 * FIX checking for RRULEs we understand
 
+* CHANGE import will read from stdin if not filenames are provided.
+
 * NEW new entry points recommended for packagers to use.
 * NEW support keyword `yesterday` for querying and creating events
 

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -432,7 +432,21 @@ def _get_cli():
                 'into or set the `default_calendar` in the config file.')
 
         # Default to stdin:
-        ics = ics or (sys.stdin,)
+        if not ics:
+            try:
+                ics_str = sys.stdin.read()
+                sys.stdin = open('/dev/tty', 'r')
+                controllers.import_ics(
+                    collection,
+                    ctx.obj['conf'],
+                    ics=ics_str,
+                    batch=batch,
+                    random_uid=random_uid,
+                    env={"calendars": ctx.obj['conf']['calendars']},
+                )
+            except FatalError as error:
+                logger.fatal(error)
+                sys.exit(1)
 
         try:
             for ics_file in ics:

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -431,6 +431,9 @@ def _get_cli():
                 'When using batch import, please specify a calendar to import '
                 'into or set the `default_calendar` in the config file.')
 
+        # Default to stdin:
+        ics = ics or (sys.stdin,)
+
         try:
             for ics_file in ics:
                 ics_str = ics_file.read()

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -410,7 +410,7 @@ def _get_cli():
     @click.option('--format', '-f', help=('The format to print the event.'))
     @click.pass_context
     def import_ics(ctx, ics, include_calendar, batch, random_uid, format):
-        '''Import events from an .ics file.
+        '''Import events from an .ics file (or stdin).
 
         If an event with the same UID is already present in the (implicitly)
         selected calendar import will ask before updating (i.e. overwriting)
@@ -519,17 +519,23 @@ def _get_cli():
             sys.exit(1)
 
     @cli.command()
-    @click.argument('ics', type=click.File('rb'))
+    @click.argument('ics', type=click.File('rb'), required=False)
     @click.option('--format', '-f',
                   help=('The format to print the event.'))
     @click.pass_context
     def printics(ctx, ics, format):
-        '''Print an ics file without importing it.
+        '''Print an ics file (or read from stdin) without importing it.
 
         Just print the ics file, do nothing else.'''
         try:
-            ics_str = ics.read()
-            controllers.print_ics(ctx.obj['conf'], ics.name, ics_str, format)
+            if ics:
+                ics_str = ics.read()
+                name = ics.name
+            else:
+                ics_str = sys.stdin.read()
+                name = 'stdin input'
+                sys.stdin = open('/dev/tty', 'r')
+            controllers.print_ics(ctx.obj['conf'], name, ics_str, format)
         except FatalError as error:
             logger.fatal(error)
             sys.exit(1)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1,6 +1,7 @@
+import datetime
 import os
 import sys
-import datetime
+from unittest import mock
 from datetime import timedelta
 
 import pytest
@@ -473,6 +474,18 @@ def test_import(runner, monkeypatch):
     result = runner.invoke(main_khal, 'import {}'.format(runner.config_file).split())
     assert not result.exception
     assert {cal['name'] for cal in fake.args[0].calendars} == {'one', 'two', 'three'}
+
+
+def test_import_from_stdin(runner):
+    ics_data = 'This is some really fake icalendar data'
+
+    with mock.patch('khal.controllers.import_ics') as mocked_import:
+        runner = runner()
+        result = runner.invoke(main_khal, ['import'], input=ics_data)
+
+    assert not result.exception
+    assert mocked_import.call_count == 1
+    assert mocked_import.call_args[1]['ics'] == ics_data
 
 
 def test_interactive_command(runner, monkeypatch):


### PR DESCRIPTION
Import from stdin if not filename is provided. This is especially useful for integrating khal with mutt.