### PR TITLE
Fix arg1 of dt.datetime.combine ()

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -73,7 +73,6 @@ from .calendarwidget import CalendarWidget
 ALL = 1
 INSTANCES = 2
 
-
 class DateConversionError(Exception):
     pass
 
@@ -870,7 +869,7 @@ class EventColumn(urwid.WidgetWrap):
             self.pane.window.alert(('alert', 'No writable calendar.'))
             return
         if end is None:
-            start = dt.datetime.combine(dt.date, dt.time(dt.datetime.now().hour))
+            start = dt.datetime.combine(dt.date.today (), dt.time(dt.datetime.now().hour))
             end = start + dt.timedelta(minutes=60)
             event = utils.new_event(
                 dtstart=start, dtend=end, summary="new event",

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -869,7 +869,7 @@ class EventColumn(urwid.WidgetWrap):
             self.pane.window.alert(('alert', 'No writable calendar.'))
             return
         if end is None:
-            start = dt.datetime.combine(dt.date.today (), dt.time(dt.datetime.now().hour))
+            start = dt.datetime.combine(date, dt.time(dt.datetime.now().hour))
             end = start + dt.timedelta(minutes=60)
             event = utils.new_event(
                 dtstart=start, dtend=end, summary="new event",


### PR DESCRIPTION
call to: ``dt.datetime.combine (dt.date, dt.time(dt.datetime.now().hour))``
fails with:
``TypeError: combine() argument 1 must be datetime.date, not type``

Test with: start ikhal, then press the ``n`` key to add a new event.
