### PR TITLE
Drop Python 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: python
 
 python:
-    - 3.3
     - 3.4
     - 3.5
     - 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -27,6 +27,7 @@ not released yet
 * CHANGE `search` will now print one line for every different event in a
   recurrence set, that is one line for the master event, and one line for every
   different overwritten event
+* CHANGE drop support for Python 3.3.
 
 * NEW khal learned the ``--logfile/-l LOGFILE`` flag which allows logging to a
   file

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Features
 - fast and easy way to add new events
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - no support for editing the timezones of events yet
-- works with python 3.3+
+- works with python 3.4+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ Features
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - only rudimentary support for creating and editing recursion rules
 - you cannot edit the timezones of events
-- works with python 3.3+
+- works with python 3.4+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -43,7 +43,7 @@ or better::
 
 in the unpacked distribution folder.
 
-Since version 0.8, *khal* **only supports python 3.3+**. If you have
+Since version 0.10, *khal* **only supports python 3.4+**. If you have
 python 2 and 3 installed in parallel you might need to use `pip3` instead of
 `pip` and `python3` instead of `python`. In case your operating system cannot
 deal with python 2 and 3 packages concurrently, we suggest installing *khal* in
@@ -60,7 +60,7 @@ then starting khal from that virtual environment.
 Requirements
 ------------
 
-*khal* is written in python and can run on Python 3.3+. It requires a Python
+*khal* is written in python and can run on Python 3.4+. It requires a Python
 with ``sqlite3`` support enabled (which is usually the case).
 
 If you are installing python via *pip* or from source, be aware that since

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 3):
-    errstr = "khal only supports python version 3.3+. Please Upgrade.\n"
+if sys.version_info < (3, 4):
+    errstr = "khal only supports python version 3.4+. Please Upgrade.\n"
     sys.stderr.write("#" * len(errstr) + '\n')
     sys.stderr.write(errstr)
     sys.stderr.write("#" * len(errstr) + '\n')
@@ -64,7 +64,6 @@ setup(
         "Environment :: Console :: Curses",
         "Intended Audience :: End Users/Desktop",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py33,py34,py35,py36}-{tests,style}-{pytz201702,pytz201610}
+envlist = {py34,py35,py36}-{tests,style}-{pytz201702,pytz201610}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.3 has reached its end of life, and no longer supported.