### PR TITLE
Fix/763

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -33,3 +33,4 @@ Stefan Siegel - ssiegel [at] sdas [dot] net
 August Lindberg
 Thomas Kluyver - thomas [at] kluyver [dot] me [dot] uk
 Tobias Brummer - hallo [at] t0bybr.de - https://t0bybr.de
+Murilo Camargos - murilofilho [dot] eng [at] gmail [dot] com

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,7 @@ not released yet
   is before today
 * FIX Check for multi_uid .ics files in vdirs and don't import those events
   (All .ics files in vdirs should only contain VEVENTS with the same UID.)
+* FIX time display of all day events
 
 * CHANGE only searched configuration file paths are now
   $XDG_CONFIG_HOME/khal/config and $XDG_CONFIG_HOME/khal/khal.conf (deprecated)

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -441,7 +441,7 @@ def edit_event(event, collection, locale, allow_quit=False, width=80):
             value = prompt("datetime range", default=current)
             try:
                 start, end, allday = parse_datetime.guessrangefstr(value, locale)
-                event.update_start_end(start, end)
+                event.update_start_end(start, end, allday)
                 edited = True
             except:  # noqa
                 echo("error parsing range")

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -171,7 +171,7 @@ class Event(object):
         except TypeError:
             raise ValueError('Cannot compare events {} and {}'.format(start, other_start))
 
-    def update_start_end(self, start, end):
+    def update_start_end(self, start, end, allday=False):
         """update start and end time of this event
 
         calling this on a recurring event will lead to the proto instance
@@ -181,6 +181,8 @@ class Event(object):
         """
         if type(start) != type(end):  # flake8: noqa
             raise ValueError('DTSTART and DTEND should be of the same type (datetime or date)')
+        if allday:
+            start = start.date()
         self.__class__ = self._get_type_from_date(start)
 
         self._vevents[self.ref].pop('DTSTART')
@@ -188,6 +190,8 @@ class Event(object):
         self._start = start
         if not isinstance(end, dt.datetime):
             end = end + dt.timedelta(days=1)
+        if allday:
+            end = end.date()
         self._end = end
         if 'DTEND' in self._vevents[self.ref]:
             self._vevents[self.ref].pop('DTEND')

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -434,6 +434,17 @@ def test_format_24():
     assert event.format(format_, dt.date(2014, 4, 9)) == '19:30-24:00 An Event\x1b[0m'
 
 
+def test_update_allday_event():
+    """test formating of events updated to all day"""
+    event_dt = _get_text('event_dt_simple')
+    start = BERLIN.localize(dt.datetime(2018, 7, 7))
+    end = BERLIN.localize(dt.datetime(2018, 7, 8))
+    event = Event.fromString(event_dt, **EVENT_KWARGS)
+    event.update_start_end(start, end, True)
+    format_ = '{start-end-time-style} {title}{repeat-symbol}'
+    assert event.format(format_, dt.date(2018, 7, 7)) == ' An Event\x1b[0m'
+
+
 def test_invalid_format_string():
     event_dt = _get_text('event_dt_simple')
     event = Event.fromString(event_dt, **EVENT_KWARGS)


### PR DESCRIPTION
This is a fix for #763. When adding an event, if `allday` flag is `True`, only the date is taken from datetime object; when updating an event, this flag wasn't being considered.