### PR TITLE
Allow all characters in calendar names

### DIFF
--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -73,7 +73,7 @@ class SQLiteDb(object):
                  locale: Dict[str, str],
                  ) -> None:
         assert db_path is not None
-        self.calendars = calendars
+        self.calendars = list(calendars)
         self.db_path = path.expanduser(db_path)
         self._create_dbdir()
         self.locale = locale
@@ -343,7 +343,7 @@ class SQLiteDb(object):
             if rec_id is not None:
                 ref = rec_inst = str(utils.to_unix_time(rec_id.dt))
             else:
-                rec_inst = dbstart
+                rec_inst = str(dbstart)
                 ref = PROTO
 
             if thisandfuture:

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -501,7 +501,7 @@ def localize_strip_tz(dates, timezone):
         yield one_date
 
 
-def to_unix_time(dtime):
+def to_unix_time(dtime: dt.datetime) -> float:
     """convert a datetime object to unix time in UTC (as a float)"""
     if getattr(dtime, 'tzinfo', None) is not None:
         dtime = dtime.astimezone(pytz.UTC)

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -127,14 +127,14 @@ class TestCollection(object):
         calendars = {
             'foobar': {'name': 'foobar', 'path': str(tmpdir), 'readonly': True},
             'home': {'name': 'home', 'path': str(tmpdir)},
-            'work': {'name': 'work', 'path': str(tmpdir), 'readonly': True},
+            "Dad's Calendar": {'name': "Dad's calendar", 'path': str(tmpdir), 'readonly': True},
         }
         coll = CalendarCollection(
             calendars=calendars, locale=LOCALE_BERLIN, dbpath=':memory:',
         )
         assert coll.default_calendar_name is None
         with pytest.raises(ValueError):
-            coll.default_calendar_name = 'work'
+            coll.default_calendar_name = "Dad's calendar"
         assert coll.default_calendar_name is None
         with pytest.raises(ValueError):
             coll.default_calendar_name = 'unknownstuff'

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,7 +5,7 @@ import pytz
 
 cal0 = 'a_calendar'
 cal1 = 'foobar'
-cal2 = 'work'
+cal2 = "Dad's calendar"
 cal3 = 'private'
 
 example_cals = [cal0, cal1, cal2, cal3]


### PR DESCRIPTION
Previously we str.format()ed calendar names in sql commands which
defeated the auto escaping done by python's sqlite package. Calendar
names containing characters like ' or ; therefore broke the sqlite
command (and allowed sql injectsions through calendar naming).

Fix #768