### PR TITLE
Control Codes

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -161,7 +161,10 @@ Several options are common to almost all of :program:`khal`'s commands
    is also `reset`, which clears the styling, and `bold`, which is the normal
    bold.
 
-   For example the below command with print the title and description of all events today.
+   A few control codes are exposed.  You can access newline (`nl`), 'tab', and 'bell'.
+   Control codes, such as `nl`, are best used with `--list` mode.
+
+   Below is an example command which prints the title and description of all events today.
 
    ::
 

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -599,6 +599,10 @@ class Event(object):
             for c in ["black", "red", "green", "yellow", "blue", "magenta", "cyan", "white"]:
                 attributes[c] = attributes[c + '-bold'] = ''
 
+        attributes['nl'] = '\n'
+        attributes['tab'] = '\t'
+        attributes['bell'] = '\a'
+
         attributes['status'] = self.status
         attributes['cancelled'] = 'CANCELLED ' if self.status == 'CANCELLED' else ''
         return format_string.format(**dict(attributes)) + attributes["reset"]


### PR DESCRIPTION
# Control Codes
## Overview

Adding control codes, `\n`, `\t`, and `\a`, which provide newline, tab and bell respectively.

Requests for newlines:

* Closes #737


Out of the available [control characters](https://en.wikipedia.org/wiki/Control_character), I felt that tab and bell would also be beneficial.  Please let me know if you disagree.

These control codes are now explained in `usage.rst`, similar to how colors are documented.


## Testing
### Validation/Manual Testing

    $ cat ~/.config/khal/config
    ...
    agenda_event_format = {calendar-color}{cancelled}{start-time-full}{to-style}{end-time-full} {title}{repeat-symbol}{nl}{tab}{location}{reset}
    ...



    $ clear && khal [--color] list
    
    Tomorrow, 2018-06-04
    09:00-9:30 Repeating Meeting ⟳
            https://link-to-meeting/
    1:30-2:00 Single Meeting
            https://link-to-meeting/


Also tested with `{bell}`, which is working, but this example is closer to what I or someone else might actually want.


### `khal` self-test


    $ py.test tests/event_test.py 
    ==================================================================================== test session starts =====================================================================================
    platform linux -- Python 3.6.5, pytest-3.6.0, py-1.5.3, pluggy-0.6.0
    rootdir: /mnt/data/src/khal, inifile:
    collected 44 items                                                                                                                                                                           
    
    tests/event_test.py ............................................                                                                                                                       [100%]
    
    ================================================================================= 44 passed in 0.29 seconds ==================================================================================



When attempting to test khal as a whole, `dateutils` is showing errors.
There are known-issues similar to this, so I'm assuming this is expected right now.
If there is something I can do to get these tests working properly, or an alternative, please let me know.  Otherwise, I'll monitor Travis.

    $ py.test test
    ...
                if (self._dtstart.tzinfo is not None) != (self._until.tzinfo is not None):
                    # According to RFC5545 Section 3.3.10:
                    # https://tools.ietf.org/html/rfc5545#section-3.3.10
                    #
                    # > If the "DTSTART" property is specified as a date with UTC
                    # > time or a date with local time and time zone reference,
                    # > then the UNTIL rule part MUST be specified as a date with
                    # > UTC time.
                    raise ValueError(
    >                   'RRULE UNTIL values must be specified in UTC when DTSTART '
                        'is timezone-aware'
                    )
    E               ValueError: RRULE UNTIL values must be specified in UTC when DTSTART is timezone-aware
    
    /usr/lib/python3.6/site-packages/dateutil/rrule.py:464: ValueError
    ====================================================================== 14 failed, 265 passed, 5 xfailed in 3.85 seconds ======================================================================




## Notes

1. These control characters are best with the `--list` output variation.
    * Using `agenda_event_format` in `config` and `--list` argument accomplish this.
1. Fixed a typo in `usage.rst`.


## Unrelated Notes

1. In addition to `pytest`, `freezegun` is required for testing.
    * ref: https://khal.readthedocs.io/en/latest/hacking.html
1. Should `.pytest_cache/*` be added to `.gitignore`?