### PR TITLE
Support Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
     - 3.4
     - 3.5
     - 3.6
-    - 3.7-dev
 
 env:
     - BUILD=py
@@ -24,6 +23,9 @@ matrix:
         env: BUILD=pytz201702
       - python: 3.6
         env: BUILD=pytz_latest
+      - python: 3.7
+        dist: xenial
+        sudo: true
 
 addons:
     apt:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -50,6 +50,8 @@ not released yet
 * NEW ikhal learned to show log messages in the header and in a new log pane,
   access with default keybinding `L`
 
+* NEW python 3.7 is now officially supported.
+
 0.9.8
 =====
 released 2017-10-05

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",
         "Topic :: Utilities",
         "Topic :: Communications",


### PR DESCRIPTION
The 3.7 stable release is out, so let's run tests with it and mark it as supported (no actual changes are required to support it).