### PR TITLE
In printformats, use time 21:45 to distinguish hours/minutes and AM/PM formats.

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -447,7 +447,7 @@ prints a list of all configured calendars.
 
 printformats
 ************
-prints a fixed date (*2013-12-21 10:09*) in all configured date(time) formats.
+prints a fixed date (*2013-12-21 21:45*) in all configured date(time) formats.
 This is supposed to help check if those formats are configured as intended.
 
 search

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -503,10 +503,10 @@ def _get_cli():
     def printformats(ctx):
         '''Print a date in all formats.
 
-        Print the date 2013-12-21 10:09 in all configured date(time)
+        Print the date 2013-12-21 21:45 in all configured date(time)
         formats to check if these locale settings are configured to ones
         liking.'''
-        time = dt.datetime(2013, 12, 21, 10, 9)
+        time = dt.datetime(2013, 12, 21, 21, 45)
         try:
             for strftime_format in [
                     'longdatetimeformat', 'datetimeformat', 'longdateformat',

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -348,11 +348,11 @@ def test_printformats(runner):
     runner = runner(days=2)
 
     result = runner.invoke(main_khal, ['printformats'])
-    assert '\n'.join(['longdatetimeformat: 21.12.2013 10:09',
-                      'datetimeformat: 21.12. 10:09',
+    assert '\n'.join(['longdatetimeformat: 21.12.2013 21:45',
+                      'datetimeformat: 21.12. 21:45',
                       'longdateformat: 21.12.2013',
                       'dateformat: 21.12.',
-                      'timeformat: 10:09',
+                      'timeformat: 21:45',
                       '']) == result.output
     assert not result.exception
 


### PR DESCRIPTION
To clearly show how the time is formatted, printformats should use a sample time like 21:45 instead of 10:09. This distinguishes hours from minutes, and 12/24 hour clocks.