### PR TITLE
Support for organizer field, refs #627

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -34,3 +34,5 @@ August Lindberg
 Thomas Kluyver - thomas [at] kluyver [dot] me [dot] uk
 Tobias Brummer - hallo [at] t0bybr.de - https://t0bybr.de
 Amanda Hickman - amanda [at] velociraptor [dot] info
+Nito Martinez - nito [at] qindel [dot] com - http://qindel.com http://theqvd.com
+

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -52,6 +52,8 @@ not released yet
 
 * NEW python 3.7 is now officially supported.
 
+* NEW format can now print the organizer of the event with '(organizer)'
+
 0.9.8
 =====
 released 2017-10-05

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -151,6 +151,17 @@ Several options are common to almost all of :program:`khal`'s commands
        The string `CANCELLED` (plus one blank) if the event's status is
        cancelled, otherwise nothing.
 
+   organizer
+       The organizer of the event. If the format has CN then it returns "CN (email)"
+       if CN does not exist it returns just the email string. Example:
+       ORGANIZER;CN=Name Surname:mailto:name@mail.com
+       returns
+       Name Surname (name@mail.com)
+       and if it has no CN attribute it returns the last element after the colon:
+       ORGANIZER;SENT-BY="mailto:toemail@mail.com":mailto:name@mail.com
+       returns
+       name@mail.com
+
    By default, all-day events have no times. To see a start and end time anyway simply
    add `-full` to the end of any template with start/end, for instance
    `start-time` becomes `start-time-full` and will always show start and end times (instead

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -573,6 +573,7 @@ class Event(object):
         attributes["repeat-symbol"] = self._recur_str
         attributes["repeat-pattern"] = self.recurpattern
         attributes["title"] = self.summary
+        attributes["organizer"] = self.organizer.strip()
         attributes["description"] = self.description.strip()
         attributes["description-separator"] = ""
         if attributes["description"]:


### PR DESCRIPTION
Simple pull request to allow to use the "organizer" field in the output format

Example:

`
khal list 01/01/2018 31/12/2018 --day-format "" --format "{start} {title} {description} {calendar} {organizer}"
`