### PR TITLE
convert categories to strings to display

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -953,7 +953,7 @@ class EventDisplay(urwid.WidgetWrap):
             lines.append(urwid.Text('Location: ' + event.location))
 
         if event.categories != '':
-            lines.append(urwid.Text('Categories: ' + event.categories))
+            lines.append(urwid.Text('Categories: ' + event.categories.to_ical().decode()))
 
         # start and end time/date
         if event.allday:


### PR DESCRIPTION
ikhal crashed with following error when opening an event with a category:

```
Traceback (most recent call last):
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/__init__.py", line 1346, in start_pane
    loop.run()
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 286, in run
    self._run()
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 384, in _run
    self.event_loop.run()
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 788, in run
    self._loop()
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 825, in _loop
    self._watch_files[fd]()
  File "/usr/lib/python3.6/site-packages/urwid/raw_display.py", line 404, in <lambda>
    event_loop, callback, self.get_available_raw_input())
  File "/usr/lib/python3.6/site-packages/urwid/raw_display.py", line 502, in parse_input
    callback(processed, processed_codes)
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 411, in _update
    self.process_input(keys)
  File "/usr/lib/python3.6/site-packages/urwid/main_loop.py", line 511, in process_input
    k = self._topmost_widget.keypress(self.screen_size, k)
  File "/usr/lib/python3.6/site-packages/urwid/wimp.py", line 648, in keypress
    return self._current_widget.keypress(size, key)
  File "/usr/lib/python3.6/site-packages/urwid/container.py", line 1131, in keypress
    return self.body.keypress( (maxcol, remaining), key )
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/__init__.py", line 1108, in keypress
    return super().keypress(size, key)
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/base.py", line 114, in keypress
    return super().keypress(size, key)
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/widgets.py", line 308, in keypress
    key = super(NextMixin, self).keypress(size, key)
  File "/usr/lib/python3.6/site-packages/urwid/container.py", line 2271, in keypress
    key = w.keypress((mc,) + size[1:], key)
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/__init__.py", line 927, in keypress
    self.view(self.focus_event.event)
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/__init__.py", line 642, in view
    (EventDisplay(self.pane._conf, event, collection=self.pane.collection),
  File "/home/noctua/.local/lib/python3.6/site-packages/khal/ui/__init__.py", line 956, in __init__
    lines.append(urwid.Text('Categories: ' + event.categories))
TypeError: must be str, not vCategory
```

I think this is the same as #828, except for the comment about colours?

Related to https://github.com/collective/icalendar/commit/20e09f352338621a31d8185d255feb61c41e42e1 I guess.