### PR TITLE
Add 'khal export' command

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -460,6 +460,45 @@ def _get_cli():
 
     @cli.command()
     @multi_calendar_option
+    @click.option('--notstarted', help=('Export only events that have not started.'),
+                  is_flag=True)
+    @click.option('--outfile', '-o', help='The output file [defaults to stdout]',
+                  type=click.File(mode='w'), default='-', metavar='OUT')
+    @click.argument('DATERANGE', nargs=-1, required=False,
+                    metavar='[DATETIME [DATETIME | RANGE]]')
+    @click.pass_context
+    def export(ctx, include_calendar, exclude_calendar, daterange, notstarted, outfile):
+        """Export to an .ics file (or stdout).
+
+        Includes all events between a start (default: today) and (optional)
+        end datetime."""
+        try:
+            events = controllers.khal_export(
+                build_collection(
+                    ctx.obj['conf'],
+                    multi_calendar_select(ctx, include_calendar, exclude_calendar)
+                ),
+                daterange=daterange,
+                notstarted=notstarted,
+                conf=ctx.obj['conf'],
+                env={"calendars": ctx.obj['conf']['calendars']}
+            )
+            if events:
+                sl = events[0].raw.split('\n')
+                header = '\n'.join(sl[:3]) + '\n' # 3 first lines of first event
+                footer = '\n'.join(sl[-2:]) # last line of first event
+                outfile.write(header)
+                for e in events:
+                    sl = e.raw.split('\n')
+                    outfile.write('\n'.join(sl[3:-2]) + '\n')
+                outfile.write(footer)
+        except FatalError as error:
+            logger.debug(error, exc_info=True)
+            logger.fatal(error)
+            sys.exit(1)
+
+    @cli.command()
+    @multi_calendar_option
     @click.pass_context
     def interactive(ctx, include_calendar, exclude_calendar):
         '''Interactive UI. Also launchable via `ikhal`.'''

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -275,6 +275,108 @@ def khal_list(collection, daterange=None, conf=None, agenda_format=None,
     return event_column
 
 
+def get_eventobjs_between(
+        collection, locale, start, end, notstarted=False,
+        env=None, seen=None, original_start=None):
+    """returns a list of event objects scheduled between start and end. Start and end
+    are strings or datetimes (of some kind).
+
+    :param collection:
+    :type collection: khalendar.CalendarCollection
+    :param start: the start datetime
+    :param end: the end datetime
+    :param env: a collection of "static" values like calendar names and color
+    :type env: dict
+    :param nostarted: True if each event should start after start (instead of
+    be active between start and end)
+    :type nostarted: bool
+    :param original_start: start datetime to compare against of notstarted is set
+    :type original_start: datetime.datetime
+    :returns: a list of Event objects
+    :rtype: list(Event)
+    """
+    assert not (notstarted and not original_start)
+
+    eventobj_list = []
+    if env is None:
+        env = {}
+    assert start
+    assert end
+    start_local = locale['local_timezone'].localize(start)
+    end_local = locale['local_timezone'].localize(end)
+
+    start = start_local.replace(tzinfo=None)
+    end = end_local.replace(tzinfo=None)
+
+    events = sorted(collection.get_localized(start_local, end_local))
+    events_float = sorted(collection.get_floating(start, end))
+    events = sorted(events + events_float)
+    for event in events:
+        # yes the logic could be simplified, but I believe it's easier
+        # to understand what's going on here this way
+        if notstarted:
+            if event.allday and event.start < original_start.date():
+                    continue
+            elif not event.allday and event.start_local < original_start:
+                    continue
+        if seen is not None and event.uid in seen:
+            continue
+        if seen is not None:
+            seen.add(event.uid)
+        eventobj_list.append(event)
+
+    return eventobj_list
+
+
+def khal_export(collection, daterange=None, conf=None,
+              notstarted=False, env=None, datepoint=None):
+    assert daterange is not None or datepoint is not None
+    """returns a list of all event objects in `daterange`"""
+    if daterange is not None:
+        start, end = start_end_from_daterange(
+            daterange, conf['locale'],
+            default_timedelta_date=conf['default']['timedelta'],
+            default_timedelta_datetime=conf['default']['timedelta'],
+        )
+        logger.debug('Getting all events between {} and {}'.format(start, end))
+
+    elif datepoint is not None:
+        if not datepoint:
+            datepoint = ['now']
+        try:
+            start, allday = parse_datetime.guessdatetimefstr(
+                datepoint, conf['locale'], dt.date.today(),
+            )
+        except ValueError:
+            raise FatalError('Invalid value of `{}` for a datetime'.format(' '.join(datepoint)))
+        if allday:
+            logger.debug('Got date {}'.format(start))
+            raise FatalError('Please supply a datetime, not a date.')
+        end = start + dt.timedelta(seconds=1)
+        logger.debug('Getting all events between {} and {}'.format(start, end))
+
+    events = []
+    if env is None:
+        env = {}
+
+    original_start = conf['locale']['local_timezone'].localize(start)
+    while start < end:
+        if start.date() == end.date():
+            day_end = end
+        else:
+            day_end = dt.datetime.combine(start.date(), dt.time.max)
+        current_events = get_eventobjs_between(
+            collection, locale=conf['locale'], start=start,
+            end=day_end, notstarted=notstarted, original_start=original_start,
+            env=env,
+            seen=set(),
+        )
+        events.extend(current_events)
+        start = dt.datetime(*start.date().timetuple()[:3]) + dt.timedelta(days=1)
+
+    return events
+
+
 def new_interactive(collection, calendar_name, conf, info, location=None,
                     categories=None, repeat=None, until=None, alarms=None,
                     format=None, env=None):


### PR DESCRIPTION
I needed to create a webcal .ics file from a calendar and could not figure out an easy way to do it. So, I ended up adapting 'khal list' to output the raw ics strings of events, with the headers of the intermediate events trimmed out. The result is this PR implementing 'khal export'. 

The code is not tested much, but works for me. If this has a chance of being accepted, I can work on it some more and add tests, documentation etc.