### PR TITLE
'/dev/tty' is not and should not be a regular file

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -22,6 +22,7 @@
 import datetime as dt
 import logging
 import os
+import stat
 import sys
 import textwrap
 from shutil import get_terminal_size
@@ -437,7 +438,7 @@ def _get_cli():
             if not ics:
                 ics_strs = (sys.stdin.read(),)
                 if not batch:
-                    if os.path.isfile('/dev/tty'):
+                    if os.stat('/dev/tty').st_mode & stat.S_IFCHR > 0:
                         sys.stdin = open('/dev/tty', 'r')
                     else:
                         logger.warning('/dev/tty does not exist, importing might not work')


### PR DESCRIPTION
When I run `khal import` using `|` from mutt, khal aborts because there's a problem with `/dev/tty`. However, there's no problem with `/dev/tty` but khal thinks it should be a regular file instead of a special char device file.

This patch changes khal to expect a special char device file instead.