### PR TITLE
Add support for other VCARD dates (e.g. X-ANNIVERSARY)

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -37,3 +37,4 @@ Amanda Hickman - amanda [at] velociraptor [dot] info
 Raef Coles - raefcoles [at] gmail [dot] com
 Nito Martinez - nito [at] qindel [dot] com - http://qindel.com http://theqvd.com
 Florian Wehner - florian [at] whnr [dot] de
+Martin Stone

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,13 @@ may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
 
+0.10.2
+======
+not released
+
+* NEW Parse `X-ANNIVERSARY`, `ANNIVERSARY` and `X-ABDATE` fields from vcards.
+
+
 0.10.1
 ======
 2019-03-30

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -311,7 +311,7 @@ class SQLiteDb(object):
                 vevent.add('uid', href + key)
                 vevent_str = vevent.to_ical().decode('utf-8')
                 self._update_impl(vevent, href + key, calendar)
-                sql_s = ('INSERT INTO events (item, etag, href, calendar) VALUES (?, ?, ?, ?);')
+                sql_s = ('INSERT OR REPLACE INTO events (item, etag, href, calendar) VALUES (?, ?, ?, ?);')
                 stuple = (vevent_str, etag, href + key, calendar)
                 self.sql_ex(sql_s, stuple)
 

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -311,7 +311,8 @@ class SQLiteDb(object):
                 vevent.add('uid', href + key)
                 vevent_str = vevent.to_ical().decode('utf-8')
                 self._update_impl(vevent, href + key, calendar)
-                sql_s = ('INSERT OR REPLACE INTO events (item, etag, href, calendar) VALUES (?, ?, ?, ?);')
+                sql_s = ('INSERT OR REPLACE INTO events (item, etag, href, calendar)'
+                         ' VALUES (?, ?, ?, ?);')
                 stuple = (vevent_str, etag, href + key, calendar)
                 self.sql_ex(sql_s, stuple)
 

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -240,7 +240,8 @@ class SQLiteDb(object):
         stuple = (vevent_str, etag, href, calendar)
         self.sql_ex(sql_s, stuple)
 
-    def update_vcf_dates(self, vevent_str: str, href: str, etag: str='', calendar: str=None) -> None:
+    def update_vcf_dates(self, vevent_str: str, href: str, etag: str='',
+                         calendar: str=None) -> None:
         """insert events from a vcard into the db
 
         This is will parse BDAY, ANNIVERSARY, X-ANNIVERSARY and X-ABDATE fields.
@@ -262,7 +263,7 @@ class SQLiteDb(object):
         ical = utils.cal_from_ics(vevent_str)
         vcard = ical.walk()[0]
         for key in vcard.keys():
-            if key in ['BDAY', 'X-ANNIVERSARY', 'ANNIVERSARY'] or key[-8:] == 'X-ABDATE':
+            if key in ['BDAY', 'X-ANNIVERSARY', 'ANNIVERSARY'] or key.endswith('X-ABDATE'):
                 date = vcard[key]
                 if isinstance(date, list):
                     logger.warning(
@@ -298,7 +299,7 @@ class SQLiteDb(object):
                 if orig_date:
                     if key == 'BDAY':
                         xtag = 'x-birthday'
-                    elif key[-11:] == 'ANNIVERSARY':
+                    elif key.endswith('ANNIVERSARY'):
                         xtag = 'x-anniversary'
                     else:
                         xtag = 'x-abdate'
@@ -639,9 +640,9 @@ def calc_shift_deltas(vevent: icalendar.Event) -> Tuple[dt.timedelta, dt.timedel
 def get_vcard_event_description(vcard: icalendar.cal.Component, key: str) -> str:
     if key == 'BDAY':
         return 'birthday'
-    elif key[-11:] == 'ANNIVERSARY':
+    elif key.endswith('ANNIVERSARY'):
         return 'anniversary'
-    elif key[-8:] == 'X-ABDATE':
+    elif key.endswith('X-ABDATE'):
         desc_key = key[:-8] + 'X-ABLABEL'
         if desc_key in vcard.keys():
             return vcard[desc_key]

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -351,11 +351,23 @@ class Event(object):
 
     @property
     def summary(self):
-        bday = self._vevents[self.ref].get('x-birthday', None)
-        if bday:
-            number = self.start_local.year - int(bday[:4])
+        description = None
+        date = self._vevents[self.ref].get('x-birthday', None)
+        if date:
+            description = 'birthday'
+        else:
+            date = self._vevents[self.ref].get('x-anniversary', None)
+            if date:
+                description = 'anniversary'
+            else:
+                date = self._vevents[self.ref].get('x-abdate', None)
+                if date:
+                    description = self._vevents[self.ref].get('x-ablabel', 'custom event')
+
+        if date:
+            number = self.start_local.year - int(date[:4])
             name = self._vevents[self.ref].get('x-fname', None)
-            if int(bday[4:6]) == 2 and int(bday[6:8]) == 29:
+            if int(date[4:6]) == 2 and int(date[6:8]) == 29:
                 leap = ' (29th of Feb.)'
             else:
                 leap = ''
@@ -367,8 +379,8 @@ class Event(object):
                 suffix = 'rd'
             else:
                 suffix = 'th'
-            return '{name}\'s {number}{suffix} birthday{leap}'.format(
-                name=name, number=number, suffix=suffix, leap=leap,
+            return '{name}\'s {number}{suffix} {desc}{leap}'.format(
+                name=name, number=number, suffix=suffix, desc=description, leap=leap,
             )
         else:
             return self._vevents[self.ref].get('SUMMARY', '')

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -324,7 +324,7 @@ class CalendarCollection(object):
         event, etag = self._storages[calendar].get(href)
         try:
             if self._calendars[calendar].get('ctype') == 'birthdays':
-                update = self._backend.update_birthday
+                update = self._backend.update_vcf_dates
             else:
                 update = self._backend.update
             update(event.raw, href=href, etag=etag, calendar=calendar)

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -782,6 +782,7 @@ def test_abdate_nolabel():
             dt.datetime(2016, 3, 11, 23, 59, 59, 999)))
     assert 'SUMMARY:Unix\'s custom event from vcard' in events[0][0]
 
+
 def test_birthday_v3():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
     assert list(db.get_floating(start, end)) == list()

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -677,6 +677,13 @@ ITEM1.X-ABDATE:19710311
 END:VCARD
 """
 
+card_v3 = """BEGIN:VCARD
+VERSION:3.0
+FN:Unix
+BDAY:1971-03-11
+END:VCARD
+"""
+
 day = dt.date(1971, 3, 11)
 start = dt.datetime.combine(day, dt.time.min)
 end = dt.datetime.combine(day, dt.time.max)
@@ -774,3 +781,17 @@ def test_abdate_nolabel():
             dt.datetime(2016, 3, 11, 0, 0),
             dt.datetime(2016, 3, 11, 23, 59, 59, 999)))
     assert 'SUMMARY:Unix\'s custom event from vcard' in events[0][0]
+
+def test_birthday_v3():
+    db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
+    assert list(db.get_floating(start, end)) == list()
+    db.update_vcf_dates(card_v3, 'unix.vcf', calendar=calname)
+    events = list(db.get_floating(start, end))
+    assert len(events) == 1
+    assert 'SUMMARY:Unix\'s birthday' in events[0][0]
+
+    events = list(
+        db.get_floating(
+            dt.datetime(2016, 3, 11, 0, 0),
+            dt.datetime(2016, 3, 11, 23, 59, 59, 999)))
+    assert 'SUMMARY:Unix\'s birthday' in events[0][0]


### PR DESCRIPTION
Fixes #243

2 problems at the moment (which Travis will report on shortly)

1) The definition line for `update_vcf_dates()` is too long (101 chars). I thought about `update_vcfdates()` or similar, but figured I'd push first and ask later.
2) There's a UNIQUE constraint violation. I can't see how the old function got around it. I'll keep looking, but help is welcome!

Other notes:
* I've changed the function and variable names to be more generic and added a docstring.
* I modified the `href` for the vcard-related events to be `href+vcard_fieldname`. This was because khal as a whole is set up for one event per file, and contacts may have e.g. a birthday and an anniversary. This might have caused (2) above...
* I might have a little time tomorrow, otherwise it will probably be a week or so before I can get back to this. Feel free to carry on in my absence or wait.
* Other feedback (style/approach/etc) welcome.