### PR TITLE
Add note about date formats to `khal new` examples.

### DIFF
--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -415,6 +415,7 @@ Options
 
 Examples
 """"""""
+These may need to be adapted for your configuration and/or locale. See :command:`printformats`.
 ::
 
     khal new 18:00 Awesome Event


### PR DESCRIPTION
Up to the maintainers whether this is necessary - Date formats are already mentioned in the description of `khal new` but it might help to cover off #884.