### PR TITLE
#805 : Add ability to define default duration

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -38,3 +38,8 @@ Raef Coles - raefcoles [at] gmail [dot] com
 Nito Martinez - nito [at] qindel [dot] com - http://qindel.com http://theqvd.com
 Florian Wehner - florian [at] whnr [dot] de
 Martin Stone
+Maxime Ocafrain
+Axel Danguin
+Yorick Barbanneau - git [at] epha [dot] se - https://xieme-art.org
+Florian Lassenay - pizzacoca [at] aquilenet [dot] fr
+Simon Crespeau - simon [at] art-e-toile [dot] com - https://www.art-e-toile.com

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * NEW Parse `X-ANNIVERSARY`, `ANNIVERSARY` and `X-ABDATE` fields from vcards.
-
+* NEW Add ability to change default event duration with
+   `default_event_duration` and `default_dayevent_duration` for an day-long 
+   event
 
 0.10.1
 ======

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -281,7 +281,10 @@ def new_interactive(collection, calendar_name, conf, info, location=None,
                     format=None, env=None):
     try:
         info = parse_datetime.eventinfofstr(
-            info, conf['locale'], adjust_reasonably=True, localize=False,
+            info, conf['locale'],
+            conf['default']['default_event_duration'],
+            conf['default']['default_dayevent_duration'],
+            adjust_reasonably=True, localize=False,
         )
     except DateTimeParseError:
         info = dict()
@@ -342,7 +345,10 @@ def new_from_string(collection, calendar_name, conf, info, location=None,
                     format=None, env=None):
     """construct a new event from a string and add it"""
     info = parse_datetime.eventinfofstr(
-        info, conf['locale'], adjust_reasonably=True, localize=False,
+        info, conf['locale'],
+        conf['default']['default_event_duration'],
+        conf['default']['default_dayevent_duration'],
+        adjust_reasonably=True, localize=False
     )
     new_from_args(
         collection, calendar_name, conf, format=format, env=env,

--- a/khal/icalendar.py
+++ b/khal/icalendar.py
@@ -156,10 +156,8 @@ def ics_from_list(events, tzs, random_uid=False, default_timezone=None):
                     continue
                 # if prop is a list, all items have the same parameters
                 datetime_ = item.dts[0].dt if hasattr(item, 'dts') else item.dt
-
                 if not hasattr(datetime_, 'tzinfo'):
                     continue
-
                 # check for datetimes' timezones which are not understood by
                 # icalendar
                 if datetime_.tzinfo is None and 'TZID' in item.params and \

--- a/khal/parse_datetime.py
+++ b/khal/parse_datetime.py
@@ -315,9 +315,10 @@ def guesstimedeltafstr(delta_string):
     return res
 
 
-def guessrangefstr(daterange, locale, adjust_reasonably=False,
+def guessrangefstr(daterange, locale,
                    default_timedelta_date=dt.timedelta(days=1),
                    default_timedelta_datetime=dt.timedelta(hours=1),
+                   adjust_reasonably=False,
                    ):
     """parses a range string
 
@@ -427,7 +428,8 @@ def rrulefstr(repeat, until, locale):
         raise FatalError()
 
 
-def eventinfofstr(info_string, locale, adjust_reasonably=False, localize=False):
+def eventinfofstr(info_string, locale, default_event_duration, default_dayevent_duration,
+                  adjust_reasonably=False, localize=False):
     """parses a string of the form START [END | DELTA] [TIMEZONE] [SUMMARY] [::
     DESCRIPTION] into a dictionary with keys: dtstart, dtend, timezone, allday,
     summary, description
@@ -455,6 +457,8 @@ def eventinfofstr(info_string, locale, adjust_reasonably=False, localize=False):
         try:
             start, end, allday = guessrangefstr(
                 ' '.join(parts[0:i]), locale,
+                default_event_duration,
+                default_dayevent_duration,
                 adjust_reasonably=adjust_reasonably,
             )
         except (ValueError, DateTimeParseError):

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -204,8 +204,17 @@ highlight_event_days = boolean(default=False)
 # `khal list`) by default.
 timedelta = timedelta(default='2d')
 
+
+# Define the defaut duration for a day-long event ('khal new' only)
+default_event_duration = timedelta(default='1d')
+
+# Define the default duration for an event ('khal new' only)
+default_dayevent_duration = timedelta(default='1h')
+
+
 # The view section contains configuration options that effect the visual appearance
 # when using khal and ikhal.
+
 [view]
 
 # Defines the behaviour of ikhal's right column. If `True`, the right column

--- a/tests/parse_datetime_test.py
+++ b/tests/parse_datetime_test.py
@@ -23,7 +23,10 @@ def _construct_event(info, locale,
                      defaulttimelen=60, defaultdatelen=1, description=None,
                      location=None, categories=None, repeat=None, until=None,
                      alarm=None, **kwargs):
-    info = eventinfofstr(' '.join(info), locale, adjust_reasonably=True, localize=False)
+    info = eventinfofstr(' '.join(info), locale,
+                         dt.timedelta(days=1),
+                         dt.timedelta(hours=1),
+                         adjust_reasonably=True, localize=False)
     if description is not None:
         info["description"] = description
     event = new_event(

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -37,6 +37,8 @@ class TestSettings(object):
                 'print_new': 'False',
                 'highlight_event_days': False,
                 'timedelta': dt.timedelta(days=2),
+                'default_event_duration': dt.timedelta(days=1),
+                'default_dayevent_duration': dt.timedelta(hours=1),
                 'show_all_days': False,
             }
         }
@@ -83,6 +85,9 @@ class TestSettings(object):
                 'print_new': 'False',
                 'highlight_event_days': False,
                 'timedelta': dt.timedelta(days=2),
+                'default_event_duration': dt.timedelta(days=1),
+                'default_dayevent_duration': dt.timedelta(hours=1),
+
                 'show_all_days': False
             }
         }


### PR DESCRIPTION
For float and allday event, this can be set on config file : 
```
[default]
# Define the defaut duration for an allday event
default_duration_date = 1d

# Define the default duration for an event
default_duration_datetime = 1h
```
