### PR TITLE
Add Python 3.7 version for testing

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}-{dateutil26,dateutil_latest}
+envlist = {py34,py35,py36,py37}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}-{dateutil26,dateutil_latest}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
As Python 3.7 is the default version for distribution like Arch or Manjaro, add it to `tox.ini`. I run all tests with this version and all work like a charm.