### PR TITLE
ikhal: Add 2 row in left pane when `frame` is `color` or `width`. Fixes #897

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,8 +20,10 @@ not released
 * FIX No warning when importing event with Windows timezone format
 * FIX Launching an external editor no longer crashes `ikhal`
 * UPDATED DEPENDENCY urwid>=1.3.0
+* FIX Wrong left pane width calculation in ikal when `frame` is `width` or 
+   `color` in configuration.
 
- 0.10.1
+0.10.1
 ======
 2019-03-30
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,7 +21,7 @@ not released
 * FIX Launching an external editor no longer crashes `ikhal`
 * UPDATED DEPENDENCY urwid>=1.3.0
 
-0.10.1
+ 0.10.1
 ======
 2019-03-30
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1061,6 +1061,8 @@ class ClassicView(Pane):
             elistbox.set_focus_date_callback = lambda _: None
         self.calendar = ContainerWidget(calendar)
         self.lwidth = 31 if self._conf['locale']['weeknumbers'] == 'right' else 28
+        if self._conf['view']['frame'] in ["width", "color"]:
+            self.lwidth += 2
         columns = NColumns(
             [(self.lwidth, self.calendar), self.eventscolumn],
             dividechars=0,


### PR DESCRIPTION
This is a simple fix for the issue. I found that left pane calculation  was wrong if we add a frame around it. We must add 2 more char in `self.lwidth` when `cont['view']['frame']` contain `'width'` or `'color'`