### PR TITLE
Implementation for the issue809 (only khal)

### DIFF
--- a/khal/calendar_display.py
+++ b/khal/calendar_display.py
@@ -51,6 +51,7 @@ def getweeknumber(date):
     return dt.date.isocalendar(date)[1]
 
 
+
 def get_calendar_color(calendar, default_color, collection):
     """Because multi-line lambdas would be un-Pythonic
     """
@@ -116,7 +117,7 @@ def str_highlight_day(
 
 def str_week(week, today, collection=None,
              hmethod=None, default_color=None, multiple=None, color=None,
-             highlight_event_days=False, locale=None, bold_for_light_color=True):
+             highlight_event_days=False, locale=None, bold_for_light_color=True, date_format_view=" "):
     """returns a string representing one week,
     if for day == today color is reversed
 
@@ -128,19 +129,20 @@ def str_week(week, today, collection=None,
              but may contain ascii escape sequences
     :rtype: str
     """
+    #date_format_digit
     strweek = ''
     for day in week:
         if day == today:
-            day = style(str(day.day).rjust(2), reverse=True)
+            day = style(str(day.day).rjust(2, date_format_view), reverse=True)
         elif highlight_event_days:
             devents = list(collection.get_calendars_on(day))
             if len(devents) > 0:
                 day = str_highlight_day(day, devents, hmethod, default_color,
                                         multiple, color, bold_for_light_color, collection)
             else:
-                day = str(day.day).rjust(2)
+                day = str(day.day).rjust(2, date_format_view)
         else:
-            day = str(day.day).rjust(2)
+            day = str(day.day).rjust(2, date_format_view)
         strweek = strweek + day + ' '
     return strweek
 
@@ -159,7 +161,8 @@ def vertical_month(month=None,
                    color='',
                    highlight_event_days=False,
                    locale=None,
-                   bold_for_light_color=True):
+                   bold_for_light_color=True,
+                   date_format_view=" "):
     """
     returns a list() of str() of weeks for a vertical arranged calendar
 
@@ -201,7 +204,7 @@ def vertical_month(month=None,
             else:
                 new_month = len(week if week[0].day <= 7 else [])
             strweek = str_week(week, today, collection, hmethod, default_color,
-                               multiple, color, highlight_event_days, locale, bold_for_light_color)
+                               multiple, color, highlight_event_days, locale, bold_for_light_color, date_format_view)
             if new_month:
                 m_name = style(calendar.month_abbr[week[6].month].ljust(month_abbr_len), bold=True)
             elif weeknumber == 'left':
@@ -220,4 +223,5 @@ def vertical_month(month=None,
         if month > 12:
             month = 1
             year = year + 1
+    # import ipdb; ipdb.set_trace
     return khal

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -83,7 +83,7 @@ def calendar(collection, agenda_format=None, notstarted=False, once=False, dater
     term_width, _ = get_terminal_size()
     lwidth = 27 if conf['locale']['weeknumbers'] == 'right' else 25
     rwidth = term_width - lwidth - 4
-
+    ldate_format_view=conf['view']['date_format_view']
     try:
         start, end = start_end_from_daterange(
             daterange, locale,
@@ -117,7 +117,8 @@ def calendar(collection, agenda_format=None, notstarted=False, once=False, dater
         color=color,
         highlight_event_days=highlight_event_days,
         locale=locale,
-        bold_for_light_color=bold_for_light_color)
+        bold_for_light_color=bold_for_light_color,
+        date_format_view=ldate_format_view)
     return merge_columns(calendar_column, event_column, width=lwidth)
 
 

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -31,10 +31,10 @@ path = expand_path(default=None)
 # hexadecimal value of the red, green and blue component, respectively.
 # When using a 24-bit color, make sure to enclose the color value in ' or "!
 # If `color` is set to *auto* (the default), khal looks for a color value in a
-# *color* file in this calendar's vdir. If the *color* file does not exist, the 
-# default_color (see below) is used. If color is set to '', the default_color is 
-# always used. Note that you can use `vdirsyncer metasync` to synchronize colors 
-# with your caldav server. 
+# *color* file in this calendar's vdir. If the *color* file does not exist, the
+# default_color (see below) is used. If color is set to '', the default_color is
+# always used. Note that you can use `vdirsyncer metasync` to synchronize colors
+# with your caldav server.
 
 color = color(default='auto')
 
@@ -119,6 +119,7 @@ longdatetimeformat = string(default='%c')
 # Enable weeknumbers in `calendar` and `interactive` (ikhal) mode. As those are
 # iso weeknumbers, they only work properly if `firstweekday` is set to 0
 weeknumbers = weeknumbers(default='off')
+
 
 # Keybindings for :command:`ikhal` are set here. You can bind more then one key
 # (combination) to a command by supplying a comma-separated list of keys.
@@ -273,6 +274,9 @@ monthdisplay = monthdisplay(default='firstday')
 # sensible choice to include the start- and end-date.
 # The syntax is the same as for :option:`--format`.
 event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{description-separator}{description}{reset}')
+
+# Specifies wich character to put before the single digit numbers on the display.
+date_format_view = string(default=' ')
 
 # When highlight_event_days is enabled, this section specifies how
 # the highlighting/coloring of days is handled.

--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -1,3 +1,4 @@
+
 # Copyright (c) 2013-2017 Christian Geier et al.
 #
 # Permission is hereby granted, free of charge, to any person obtaining

--- a/tests/cal_display_test.py
+++ b/tests/cal_display_test.py
@@ -30,8 +30,8 @@ def test_str_week():
             dt.date(2012, 6, 11),
             dt.date(2012, 6, 12),
             dt.date(2012, 6, 13)]
-    assert str_week(week, aday) == ' 6  7  8  9 10 11 12 13 '
-    assert str_week(week, bday) == ' 6  7 \x1b[7m 8\x1b[0m  9 10 11 12 13 '
+    assert str_week(week, aday) == ' 6  7  8  9 10 11 12 13 ' or '06 07 08 09 10 11 12 13 '
+    assert str_week(week, bday) == ' 6  7 \x1b[7m 8\x1b[0m  9 10 11 12 13 ' or '06 07 \x1b[07m08\x1b[0m 09 10 11 12 13 '
 
 
 class testCollection():

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -262,7 +262,26 @@ def test_calendar(runner):
             "Sep 31  1  2  3  4  5  6     ",
             "",
         ])
-        assert result.output == output
+        # Added output for the case where you want 0 before the single digit numbers
+        output0 = '\n'.join([
+            "    Mo Tu We Th Fr Sa Su     No events",
+            "Jun 01 02 03 04 05 06 07     ",
+            "    08 09 10 11 12 13 14     ",
+            "    15 16 17 18 19 20 21     ",
+            "    22 23 24 25 26 27 28     ",
+            "Jul 29 30 01 02 03 04 05     ",
+            "    06 07 08 09 10 11 12     ",
+            "    13 14 15 16 17 18 19     ",
+            "    20 21 22 23 24 25 26     ",
+            "Aug 27 28 29 30 31 01 02     ",
+            "    03 04 05 06 07 08 09     ",
+            "    10 11 12 13 14 15 16     ",
+            "    17 18 19 20 21 22 23     ",
+            "    24 25 26 27 28 29 30     ",
+            "Sep 31 01 02 03 04 05 06     ",
+            "",
+        ])
+        assert result.output == output or output0
 
 
 def test_long_calendar(runner):
@@ -293,7 +312,30 @@ def test_long_calendar(runner):
             "Oct 28 29 30  1  2  3  4     ",
             "",
         ])
-        assert result.output == output
+        # Added output for the case where you want 0 before the single digit numbers
+        output0 = '\n'.join([
+            "    Mo Tu We Th Fr Sa Su     No events",
+            "Jun 01 02 03 04 05 06 07     ",
+            "    08 09 10 11 12 13 14     ",
+            "    15 16 17 18 19 20 21     ",
+            "    22 23 24 25 26 27 28     ",
+            "Jul 29 30 01 02 03 04 05     ",
+            "    06 07 08 09 10 11 12     ",
+            "    13 14 15 16 17 18 19     ",
+            "    20 21 22 23 24 25 26     ",
+            "Aug 27 28 29 30 31 01 02     ",
+            "    03 04 05 06 07 08 09     ",
+            "    10 11 12 13 14 15 16     ",
+            "    17 18 19 20 21 22 23     ",
+            "    24 25 26 27 28 29 30     ",
+            "Sep 31 01 02 03 04 05 06     ",
+            "    07 08 09 10 11 12 13     ",
+            "    14 15 16 17 18 19 20     ",
+            "    21 22 23 24 25 26 27     ",
+            "Oct 28 29 30 01 02 03 04     ",
+            "",
+        ])
+        assert result.output == output or output0
 
 
 def test_default_command_empty(runner):


### PR DESCRIPTION
Added a solution for the issue #809 where you can define a specific character to put before the single digit numbers in khal, such as "0" to get the output to be  `01, 02, 03, etc` instead of `1, 2, 3, etc`.

The parameter I added can be found in "khal/settings/khal.spec" under the [view] section, named `date_format_view = string(default=' ')`.
Also added some "test cases" for `01, 02, 03, etc` output.