### PR TITLE
Add `{uid}` property to template options in `--format`. Fixes #891

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ not released
 * NEW Add ability to change default event duration with
    `default_event_duration` and `default_dayevent_duration` for an day-long 
    event
+* NEW Add `{uid}` property to template options in `--format`
 
 0.10.1
 ======

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -73,6 +73,12 @@ Several options are common to almost all of :program:`khal`'s commands
    description
         The description of the event.
 
+   description-separator
+        A separator: " :: " that appears when there is a description.
+
+   uid
+        The UID of the event.
+
    start
         The start datetime in datetimeformat.
 
@@ -105,12 +111,6 @@ Several options are common to almost all of :program:`khal`'s commands
 
    repeat-symbol
         A repeating symbol (loop arrow) if the event is repeating.
-
-   description
-        The event description.
-
-   description-separator
-        A separator: " :: " that appears when there is a description.
 
    location
         The event location.

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -596,6 +596,7 @@ class Event(object):
         attributes["location"] = self.location.strip()
         attributes["all-day"] = allday
         attributes["categories"] = self.categories
+        attributes['uid'] = self.uid
 
         if "calendars" in env and self.calendar in env["calendars"]:
             cal = env["calendars"][self.calendar]

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -677,7 +677,7 @@ def test_print_ics_command(runner):
     assert not result.exception
 
     # Test with some nice format strings
-    form = '{title}\t{description}\t{start}\t{start-long}\t{start-date}' \
+    form = '{uid}\t{title}\t{description}\t{start}\t{start-long}\t{start-date}' \
            '\t{start-date-long}\t{start-time}\t{end}\t{end-long}\t{end-date}' \
            '\t{end-date-long}\t{end-time}\t{repeat-symbol}\t{description}' \
            '\t{description-separator}\t{location}\t{calendar}' \
@@ -686,11 +686,11 @@ def test_print_ics_command(runner):
     result = runner.invoke(main_khal, [
         'printics', '-f', form, _get_ics_filepath('cal_dt_two_tz')])
     assert not result.exception
-    assert 24 == len(result.output.split('\t'))
+    assert 25 == len(result.output.split('\t'))
     result = runner.invoke(main_khal, [
         'printics', '-f', form, _get_ics_filepath('cal_dt_two_tz')])
     assert not result.exception
-    assert 24 == len(result.output.split('\t'))
+    assert 25 == len(result.output.split('\t'))
 
 
 def test_printics_read_from_stdin(runner):


### PR DESCRIPTION
A quick fix that adds the `{uid}` as an option for use in formats.

I couldn't decide whether a test for this option was necessary as the current tests seem to test formatting more generically.