### PR TITLE
Force CalendarWidget to selectable. Fixes #903.

### DIFF
--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -643,6 +643,10 @@ class CalendarWidget(urwid.WidgetWrap):
     def reset_styles_range(self, min_date, max_date):
         self.walker.reset_styles_range(min_date, max_date)
 
+    @classmethod
+    def selectable(cls):
+        return True
+
     @property
     def focus_date(self):
         return self.walker.focus_date


### PR DESCRIPTION
I'd like to know more about what's going on, but for now:
 - This fixes the test (#903)
 - "Playing around" on urwid 2.1.0 I couldn't see any problems, nor any other widgets that seemed to need the forced `selectable` property.
 - This was copied from the `EventEditor` class, but the same or similar is used on other widgets.