### PR TITLE
Remove testing for dateutil 2.6. Fixes #915.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,6 @@ matrix:
         env: BUILD=pytz201702
       - python: 3.6
         env: BUILD=pytz_latest
-      - python: 3.6
-        env: BUILD=dateutil26
-      - python: 3.6
-        env: BUILD=dateutil_latest
       - python: 3.7
         dist: xenial
         sudo: true

--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -643,6 +643,10 @@ class CalendarWidget(urwid.WidgetWrap):
     def reset_styles_range(self, min_date, max_date):
         self.walker.reset_styles_range(min_date, max_date)
 
+    @classmethod
+    def selectable(cls):
+        return True
+
     @property
     def focus_date(self):
         return self.walker.focus_date

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}-{dateutil26,dateutil_latest}
+envlist = {py34,py35,py36}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]
@@ -18,12 +18,11 @@ deps =
     pytest
     freezegun
     vdirsyncer
+    python-dateutil
     pytz201702: pytz==2017.2
     pytz201610: pytz==2016.10
     pytz_latest: pytz
     py34: typing
-    dateutil26: python-dateutil<2.7
-    dateutil_latest: python-dateutil
 
 commands =
     py.test {posargs}


### PR DESCRIPTION
Option 1. As it's only testing that changes (it's `freezegun`'s dependency, not ours) I haven't added it to the changelog.