### PR TITLE
Force dateutil 2.6 tests to use compatible freezegun (<0.3.15). Fixes #915.

### DIFF
--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -643,6 +643,10 @@ class CalendarWidget(urwid.WidgetWrap):
     def reset_styles_range(self, min_date, max_date):
         self.walker.reset_styles_range(min_date, max_date)
 
+    @classmethod
+    def selectable(cls):
+        return True
+
     @property
     def focus_date(self):
         return self.walker.focus_date

--- a/tox.ini
+++ b/tox.ini
@@ -16,14 +16,15 @@ passenv =
   TRAVIS_REPO_SLUG
 deps =
     pytest
-    freezegun
     vdirsyncer
     pytz201702: pytz==2017.2
     pytz201610: pytz==2016.10
     pytz_latest: pytz
     py34: typing
     dateutil26: python-dateutil<2.7
+    dateutil26: freezegun<0.3.15
     dateutil_latest: python-dateutil
+    !dateutil26: freezegun
 
 commands =
     py.test {posargs}


### PR DESCRIPTION
Option 2.