### PR TITLE
Remove warning about missing timezones in repeated events. Fixes #830. Fixes #920.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,9 @@ not released
 * UPDATED DEPENDENCY urwid>=1.3.0
 * FIX Wrong left pane width calculation in ikal when `frame` is `width` or 
    `color` in configuration.
+* CHANGE Remove check for timezones in `UNTIL` that aren't in `DTSTART` and 
+   vice-versa. The check wasn't fulfilling its purpose and was raising warnings
+   when no `UNTIL` value was set.
 
 0.10.1
 ======

--- a/khal/icalendar.py
+++ b/khal/icalendar.py
@@ -244,18 +244,6 @@ def expand(vevent, href=''):
         dtstart = vevent['DTSTART'].dt
         if events_tz:
             dtstart = dtstart.replace(tzinfo=None)
-        if events_tz and 'Z' not in rrule_param.to_ical().decode():
-            logger.warning(
-                "In event {}, DTSTART has a timezone, but UNTIL does not. This "
-                "might lead to errenous repeating instances (like missing the "
-                "last intended instance or adding an extra one)."
-                "".format(href))
-        elif not events_tz and 'Z' in rrule_param.to_ical().decode():
-            logger.warning(
-                "In event {}, DTSTART has no timezone, but UNTIL has one. This "
-                "might lead to errenous repeating instances (like missing the "
-                "last intended instance or adding an extra one)."
-                "".format(href))
 
         rrule = dateutil.rrule.rrulestr(
             rrule_param.to_ical().decode(),


### PR DESCRIPTION
Looks like there are two issues here:

1) The simpler, more obvious problem that this error is raised even if `UNTIL` is not set. That's an easy fix (I have a branch with that if this check is still useful)

2) If a timezone not set on the command line (and, as far as I can tell, it can't be set from `ikhal`), the timezone of `DTSTART` is assigned implicitly (in `eventinfofstr()`, called by `new_from_string()`), before this check. This is not done for `UNTIL` and, as far as I can see, renders this check pointless as `DSTART` will always have a timezone regardless of the command line used, so we have no information about whether a timezone was passed with `DTSTART` to compare with `UNTIL`.

This patch removes the check, as it appears to have insufficient information to warn appropriately.