### PR TITLE
Drop support for Python 3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 os: linux
 
 python:
-    - 3.4
     - 3.5
     - 3.6
     - 3.7

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ may want to subscribe to `GitHub's tag feed
 ======
 not released
 
+* DROPPED support for Python 3.4
 * FIX `khal interactive` now accepts -a/-d options (as documented)
 * FIX Strip whitespace when loading `displayname` and `color` files
 * FIX Warn when loading events with a recurrence that finishes before it starts

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Features
 - fast and easy way to add new events
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - no support for editing the timezones of events yet
-- works with python 3.4+
+- works with python 3.5+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ Features
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - only rudimentary support for creating and editing recursion rules
 - you cannot edit the timezones of events
-- works with python 3.4+
+- works with python 3.5+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -48,7 +48,7 @@ or better::
 
 in the unpacked distribution folder.
 
-Since version 0.10, *khal* **only supports python 3.4+**. If you have
+Since version 0.10, *khal* **only supports python 3.5+**. If you have
 python 2 and 3 installed in parallel you might need to use `pip3` instead of
 `pip` and `python3` instead of `python`. In case your operating system cannot
 deal with python 2 and 3 packages concurrently, we suggest installing *khal* in
@@ -65,7 +65,7 @@ then starting khal from that virtual environment.
 Requirements
 ------------
 
-*khal* is written in python and can run on Python 3.4+. It requires a Python
+*khal* is written in python and can run on Python 3.5+. It requires a Python
 with ``sqlite3`` support enabled (which is usually the case).
 
 If you are installing python via *pip* or from source, be aware that since

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 4):
-    errstr = "khal only supports python version 3.4+. Please Upgrade.\n"
+if sys.version_info < (3, 5):
+    errstr = "khal only supports python version 3.5+. Please Upgrade.\n"
     sys.stderr.write("#" * len(errstr) + '\n')
     sys.stderr.write(errstr)
     sys.stderr.write("#" * len(errstr) + '\n')
@@ -31,7 +31,6 @@ test_requirements = [
 
 extra_requirements = {
     'proctitle': ['setproctitle'],
-    ':python_version < "3.5"': 'typing',
 }
 
 setup(
@@ -65,7 +64,6 @@ setup(
         "Environment :: Console :: Curses",
         "Intended Audience :: End Users/Desktop",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py34,py35,py36,py37,py38,py39}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}
+envlist = {py35,py36,py37,py38,py39}-{tests,style,mypy}-{pytz201702,pytz201610,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]
@@ -22,7 +22,6 @@ deps =
     pytz201702: pytz==2017.2
     pytz201610: pytz==2016.10
     pytz_latest: pytz
-    py34: typing
 
 commands =
     py.test {posargs}


### PR DESCRIPTION
No rush yet, but Python 3.4 is out of support, so we can probably drop it. That said we could leave it until it breaks, especially as this patch would block setup.py on 3.4.