### PR TITLE
Stop and start the whole urwid loop instead of the screen when launch…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,12 +12,14 @@ may want to subscribe to `GitHub's tag feed
 ======
 not released
 
-* NEW Parse `X-ANNIVERSARY`, `ANNIVERSARY` and `X-ABDATE` fields from vcards.
+* NEW Parse `X-ANNIVERSARY`, `ANNIVERSARY` and `X-ABDATE` fields from vcards
 * NEW Add ability to change default event duration with
    `default_event_duration` and `default_dayevent_duration` for an day-long 
    event
 * NEW Add `{uid}` property to template options in `--format`
 * FIX No warning when importing event with Windows timezone format
+* FIX Launching an external editor no longer crashes `ikhal`
+* UPDATED DEPENDENCY urwid>=1.3.0
 
 0.10.1
 ======

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -10,12 +10,6 @@ Frequently asked questions:
       takes nearly as much time as running khal, uncompressing that file via
       pytz via `(sudo) pip unzip pytz` might help.
 
-* **ikhal raises an Exception: AttributeError: 'module' object has no attribute 'SimpleFocusListWalker'**
-        You probably need to upgrade urwid to version 1.1.0, if your OS does come with
-        an older version of *urwid* you can install the latest version to userspace
-        (without messing up your default installation) with `pip install --upgrade urwid --user`.
-
-
 * **Installation stops with an error: source/str_util.c:25:20: fatal error: Python.h: No such file or directory**
         You do not have the Python development headers installed, on Debian based
         Distributions you can install them via *aptitude install python-dev*.

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -733,9 +733,9 @@ class EventColumn(urwid.WidgetWrap):
 
         assert not self.editor
         if external_edit:
-            self.pane.window.loop.screen.stop()
+            self.pane.window.loop.stop()
             text = click.edit(event.raw)
-            self.pane.window.loop.screen.start()
+            self.pane.window.loop.start()
             if text is None:
                 return
             # KeyErrors can occurr here when we destroy DTSTART,

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     'click>=3.2',
     'click_log>=0.2.0',
     'icalendar>=4.0.3',
-    'urwid',
+    'urwid>=1.3.0',
     'pyxdg',
     'pytz',
     'python-dateutil',


### PR DESCRIPTION
…ing an external editor. Fixes #827. Workaround for urwid/urwid#285.

I've added a version requirement for urwid >= 1.3.0 because the workaround requires it. Accordingly I've removed the FAQ entry about upgrading to urwid >= 1.1.0. 1.3.0 was released in 2014, so that's probably safe.