### PR TITLE
Change default format of printics to event_format

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -622,7 +622,7 @@ def import_event(vevent, collection, locale, batch, format=None, env=None):
 
 def print_ics(conf, name, ics, format):
     if format is None:
-        format = conf['view']['agenda_event_format']
+        format = conf['view']['event_format']
     cal = cal_from_ics(ics)
     events = [item for item in cal.walk() if item.name == 'VEVENT']
     events_grouped = defaultdict(list)

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -705,7 +705,7 @@ def test_printics_read_from_stdin(runner):
     runner = runner(command='printics')
     result = runner.invoke(main_khal, ['printics'], input=_get_text('cal_d'))
     assert not result.exception
-    assert '1 events found in stdin input\n An Event\n' in result.output
+    assert '1 events found in stdin input\n09.04.-09.04. An Event\n' in result.output
 
 
 def test_configure_command_config_exists(runner):


### PR DESCRIPTION
It seems more reasonable to use `event_format` instead of `agenda_event_format` as the default format for the `printics` command, since the date ist not clear through context.

Fixes #941 