### PR TITLE
Strip whitespace from displayname and color metadata files. Fixes #783.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * FIX `khal interactive` now accepts -a/-d options (as documented)
+* FIX Strip whitespace when loading `displayname` and `color` files
 
 0.10.2
 ======

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -267,7 +267,7 @@ class VdirBase:
         fpath = os.path.join(self.path, key)
         try:
             with open(fpath, 'rb') as f:
-                return f.read().decode(self.encoding) or None
+                return f.read().decode(self.encoding).strip() or None
         except IOError as e:
             if e.errno == errno.ENOENT:
                 return None


### PR DESCRIPTION
I'm going to leave this here for a week or two in case someone can think of an unintended consequence to this approach.

The modified function is only used to load `displayname` and `color` files. I could limit the `strip()` to newlines, but leading/trailing spaces are also likely to cause confusion here.