### PR TITLE
ikhal: Don't (re)sort the list of events as this will move all-day events to the end of the day.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * FIX `khal interactive` now accepts -a/-d options (as documented)
+* FIX Display all-day events at the top of the day in `ikhal`
 
 0.10.2
 ======

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -474,7 +474,7 @@ class DayWalker(urwid.SimpleFocusListWalker):
             conf=self._conf,
         )
         event_list.append(urwid.AttrMap(date_header, 'date'))
-        self.events = sorted(self._collection.get_events_on(day))
+        self.events = self._collection.get_events_on(day)
         event_list.extend([
             urwid.AttrMap(
                 U_Event(event, conf=self._conf, this_date=day, delete_status=self.delete_status),


### PR DESCRIPTION
Fixes #976

The events appear to still by in the correct order after removing the `sorted()` wrapper. Once again I'll leave this up a week or so in the hope that any unintended consequences are spotted before merge.

Comparing `khal calendar` with `ikhal`, both seem to use `sorted()`, but with different results. It's also worth noting that the events are sorted by calendar. I don't know whether that's deliberate.

I'm going to leave this here, but I'm going to try to find a better option.