### PR TITLE
Add a blank line before day line on khal list / calendar. Fixes #968

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ not released
 * FIX Alarms without descriptions no longer crash `ikhal`
 * FIX Display all-day events at the top of the day in `ikhal`
 * FIX Keybindings in empty search results no longer crash `ikhal`
+* NEW Possibility to adda bank line before day in `khal` with
+   `blank_line_before_day` option
 
 0.10.2
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ not released
 * FIX Alarms without descriptions no longer crash `ikhal`
 * FIX Display all-day events at the top of the day in `ikhal`
 * FIX Keybindings in empty search results no longer crash `ikhal`
-* NEW Possibility to adda bank line before day in `khal` with
+* NEW Possibility to add a blank line before day in `khal` with
    `blank_line_before_day` option
 
 0.10.2

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -267,6 +267,8 @@ def khal_list(collection, daterange=None, conf=None, agenda_format=None,
             width=width,
         )
         if day_format and (conf['default']['show_all_days'] or current_events):
+            if len(event_column) != 0 and conf['view']['blank_line_before_day']:
+                event_column.append('')
             event_column.append(format_day(start.date(), day_format, conf['locale']))
         event_column.extend(current_events)
         start = dt.datetime(*start.date().timetuple()[:3]) + dt.timedelta(days=1)

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -230,6 +230,9 @@ event_view_weighting = integer(default=1)
 # Set to true to always show the event view window when looking at the event list
 event_view_always_visible = boolean(default=False)
 
+# Add a blank line before the name of the day (khal only) 
+blank_line_before_day = boolean(default=False)
+
 # Choose a color theme for khal.
 #
 # This is very much work in progress. Help is really welcome! The two currently


### PR DESCRIPTION
Add a blank line before the day / date line in `khal list` and `khal calendar` except for the first one. Update test in `cli_test.py`.

List is more cleared with this in my opinion.