### PR TITLE
Improve sorting of events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ not released
 * NEW Possibility to add a blank line before day in `khal` with
    `blank_line_before_day` option
 * FIX `new` keybinding in search no longer crash `ikhal`
+* NEW Improved sorting of events. Sort by `DTSTART`, `DTEND` then `SUMMARY`.
 
 0.10.2
 ======

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -161,12 +161,33 @@ class Event(object):
             start = dt.datetime.combine(start, dt.time.min)
 
         if isinstance(other_start, dt.date) and not isinstance(other_start, dt.datetime):
-            other_start = dt.datetime.combine(other_start, dt.time.max)
+            other_start = dt.datetime.combine(other_start, dt.time.min)
 
         start = start.replace(tzinfo=None)
         other_start = other_start.replace(tzinfo=None)
+
+        if start == other_start:
+            end = self.end_local
+            other_end = other.end_local
+            if isinstance(end, dt.date) and not isinstance(end, dt.datetime):
+                end = dt.datetime.combine(end, dt.time.min)
+
+            if isinstance(other_end, dt.date) and not isinstance(other_end, dt.datetime):
+                other_end = dt.datetime.combine(other_end, dt.time.min)
+
+            end = end.replace(tzinfo=None)
+            other_end = other_end.replace(tzinfo=None)
+
+            if end == other_end:
+                return self.summary < other.summary
+
+            try:
+                return end < other_end
+            except TypeError:
+                raise ValueError('Cannot compare events {} and {}'.format(end, other_end))
+
         try:
-            return start <= other_start
+            return start < other_start
         except TypeError:
             raise ValueError('Cannot compare events {} and {}'.format(start, other_start))
 

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -499,3 +499,31 @@ UID:V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU
 END:VEVENT
 END:VCALENDAR"""
         )
+
+def test_sort_date_vs_datetime():
+    event1 = Event.fromString(_get_text('event_d'), **EVENT_KWARGS)
+    event2 = Event.fromString(_get_text('event_dt_floating'), **EVENT_KWARGS)
+    assert event1 < event2
+
+def test_sort_event_start():
+    event_dt = _get_text('event_dt_simple')
+    start = BERLIN.localize(dt.datetime(2014, 4, 9, 9, 45))
+    end = BERLIN.localize(dt.datetime(2014, 4, 9, 10, 30))
+    event1 = Event.fromString(event_dt, **EVENT_KWARGS)
+    event2 = Event.fromString(event_dt, start=start, end=end, **EVENT_KWARGS)
+    assert event1 < event2
+
+def test_sort_event_end():
+    event_dt = _get_text('event_dt_simple')
+    start = BERLIN.localize(dt.datetime(2014, 4, 9, 9, 30))
+    end = BERLIN.localize(dt.datetime(2014, 4, 9, 10, 45))
+    event1 = Event.fromString(event_dt, **EVENT_KWARGS)
+    event2 = Event.fromString(event_dt, start=start, end=end, **EVENT_KWARGS)
+    assert event1 < event2
+
+def test_sort_event_summary():
+    event_dt = _get_text('event_dt_simple')
+    event1 = Event.fromString(event_dt, **EVENT_KWARGS)
+    event2 = Event.fromString(event_dt, **EVENT_KWARGS)
+    event2.update_summary("ZZZ")
+    assert event1 < event2


### PR DESCRIPTION
Sort by start, then end, then summary.

Closes #981. Fixes #976.

This may need some refactoring, maybe some comments and probably needs some tests. But the concept should be ready for review.