### PR TITLE
Move all-day events above other events in ikhal (to match khal).

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ not released
 * FIX Strip whitespace when loading `displayname` and `color` files
 * FIX Warn when loading events with a recurrence that finishes before it starts
 * FIX Alarms without descriptions no longer crash `ikhal`
+* FIX Display all-day events at the top of the day in `ikhal`
 
 0.10.2
 ======

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -150,7 +150,7 @@ class CalendarCollection(object):
         floating_events = self.get_floating(start, end)
         localize = self._locale['local_timezone'].localize
         localized_events = self.get_localized(localize(start), localize(end))
-        return itertools.chain(floating_events, localized_events)
+        return itertools.chain(localized_events, floating_events)
 
     def get_calendars_on(self, day: dt.date) -> List[str]:
         start = dt.datetime.combine(day, dt.time.min)


### PR DESCRIPTION
This is a much simpler solution and confirms my theory in #981 - They are passed in a different order, and because `<=` is used instead of `<` the ordering matters.

Fixes #976. Closes #980.