### PR TITLE
docs: fix simple typo, occurr -> occur

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -738,7 +738,7 @@ class EventColumn(urwid.WidgetWrap):
             self.pane.window.loop.start()
             if text is None:
                 return
-            # KeyErrors can occurr here when we destroy DTSTART,
+            # KeyErrors can occur here when we destroy DTSTART,
             # otherwise, even broken .ics files seem to be no problem
             new_event = Event.fromString(
                 text,


### PR DESCRIPTION
There is a small typo in khal/ui/__init__.py.

Should read `occur` rather than `occurr`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md