### PR TITLE
Fix #997 crash on ikhal when create a new event when search context is active

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ not released
 * FIX Keybindings in empty search results no longer crash `ikhal`
 * NEW Possibility to add a blank line before day in `khal` with
    `blank_line_before_day` option
+* FIX `new` keybinding in search no longer crash `ikhal`
 
 0.10.2
 ======

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -874,6 +874,8 @@ class EventColumn(urwid.WidgetWrap):
         if not self.pane.collection.writable_names:
             self.pane.window.alert(('alert', 'No writable calendar.'))
             return
+        if date is None:
+            date = dt.datetime.now()
         if end is None:
             start = dt.datetime.combine(date, dt.time(dt.datetime.now().hour))
             end = start + dt.timedelta(minutes=60)


### PR DESCRIPTION
 When search context is active, `self.focus_date` is undefined then if user create a new event in this context `new()` crash. This PR add a test in `new()` and initialize start `date` with `datetine.now()` 