### PR TITLE
All day event process correctly with --notstarted, fix #1004

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -187,7 +187,7 @@ def get_events_between(
         # yes the logic could be simplified, but I believe it's easier
         # to understand what's going on here this way
         if notstarted:
-            if event.allday and event.start < original_start.date():
+            if event.allday and event.start <= original_start.date():
                 continue
             elif not event.allday and event.start_local < original_start:
                 continue


### PR DESCRIPTION
When you do `khal list --notstarted`, the "today" all-day event is displayed. This MR avoid this problem.