### PR TITLE
Docs: date/time formats may need to be quoted in config files

### DIFF
--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -15,6 +15,8 @@ path = ~/.khal/khal.db
 local_timezone = Europe/Berlin
 default_timezone = America/New_York
 
+# If you use certain characters (e.g. commas) in these formats you may need to
+# enclose them in "" to ensure that they are loaded as strings.
 timeformat = %H:%M
 dateformat = %d.%m.
 longdateformat = %d.%m.%Y

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -98,6 +98,9 @@ local_timezone = timezone(default=None)
 # The formatting string is interpreted as defined by Python's `strftime
 # <https://docs.python.org/3/library/time.html#time.strftime>`_, which is
 # similar to the format specified in ``man strftime``.
+
+# In the configuration file it may be necessary to enclose the format in
+# quotation marks to force it to be loaded as a string.
 timeformat = string(default='%X')
 
 # khal will display and understand all dates in this format, see :ref:`timeformat <locale-timeformat>` for the format


### PR DESCRIPTION
Add notes in the docs and the example config file about quoting date/time formats in some circumstances, to cover the issue encountered in #1007.

Closes #1007