### PR TITLE
Let pytest remove all tmp files and folders

### DIFF
--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -375,6 +375,7 @@ class TestDbCreation(object):
         calendars = {cal1: {'name': cal1, 'path': str(tmpdir)}}
         with pytest.raises(CouldNotCreateDbDir):
             CalendarCollection(calendars, dbpath=dbpath, locale=LOCALE_BERLIN)
+        os.chmod(str(tmpdir), 777)
 
 
 def test_event_different_timezones(coll_vdirs):


### PR DESCRIPTION
In some tests we set some temporary directories' permissions so that those directories are not accessible anymore. We now reset those permissions afterwards so that they can be cleaned up by pytest after the tests have run.