### PR TITLE
Use new syntax for validate. Fixes #993.

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -12,10 +12,15 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import validate
 from configobj import ConfigObj
 
 import khal
+
+try:
+    # Available from configobj 5.1.0
+    import configobj.validate
+except ModuleNotFoundError:
+    import validate
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/khal/settings/settings.py
+++ b/khal/settings/settings.py
@@ -26,9 +26,14 @@ import os
 import xdg.BaseDirectory
 from configobj import (ConfigObj, ConfigObjError, flatten_errors,
                        get_extra_values)
-from validate import Validator
 
 from khal import __productname__
+
+try:
+    # Available from configobj 5.1.0
+    from configobj.validate import Validator
+except ModuleNotFoundError:
+    from validate import Validator
 
 from .exceptions import (CannotParseConfigFileError, InvalidSettingsError,
                          NoConfigFile)

--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -30,7 +30,12 @@ from typing import Optional
 import pytz
 import xdg
 from tzlocal import get_localzone
-from validate import VdtValueError
+
+try:
+    # Available from configobj 5.1.0
+    from configobj.validate import VdtValueError
+except ModuleNotFoundError:
+    from validate import VdtValueError
 
 from ..khalendar.vdir import CollectionNotFoundError, Vdir
 from ..parse_datetime import guesstimedeltafstr

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -3,7 +3,6 @@ import os.path
 
 import pytest
 from tzlocal import get_localzone as _get_localzone
-from validate import VdtValueError
 
 from khal.settings import get_config
 from khal.settings.exceptions import (CannotParseConfigFileError,
@@ -11,6 +10,12 @@ from khal.settings.exceptions import (CannotParseConfigFileError,
 from khal.settings.utils import (config_checks, get_all_vdirs,
                                  get_color_from_vdir, get_unique_name,
                                  is_color)
+
+try:
+    # Available from configobj 5.1.0
+    from configobj.validate import VdtValueError
+except ModuleNotFoundError:
+    from validate import VdtValueError
 
 from .utils import LOCALE_BERLIN
 


### PR DESCRIPTION
configobj 5.1.0+ has integrated validate and will eventually want a new syntax. 5.1.0 has a shim to allow the old syntax to work for now. Until we set a minimum version of configobj we should cover both imports.