### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 os: linux
 
 python:
-    - 3.5
     - 3.6
     - 3.7
     - 3.8

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ may want to subscribe to `GitHub's tag feed
 ======
 not released
 
+* DROPPED support for Python 3.5
+
 0.10.3
 ======
 2021-04-27

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Features
 - fast and easy way to add new events
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - no support for editing the timezones of events yet
-- works with python 3.5+
+- works with python 3.6+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ Features
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - only rudimentary support for creating and editing recursion rules
 - you cannot edit the timezones of events
-- works with python 3.5+
+- works with python 3.6+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -48,7 +48,7 @@ or better::
 
 in the unpacked distribution folder.
 
-Since version 0.10, *khal* **only supports python 3.5+**. If you have
+Since version 0.10, *khal* **only supports python 3.6+**. If you have
 python 2 and 3 installed in parallel you might need to use `pip3` instead of
 `pip` and `python3` instead of `python`. In case your operating system cannot
 deal with python 2 and 3 packages concurrently, we suggest installing *khal* in

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 5):
-    errstr = "khal only supports python version 3.5+. Please Upgrade.\n"
+if sys.version_info < (3, 6):
+    errstr = "khal only supports python version 3.6+. Please Upgrade.\n"
     sys.stderr.write("#" * len(errstr) + '\n')
     sys.stderr.write(errstr)
     sys.stderr.write("#" * len(errstr) + '\n')
@@ -64,7 +64,7 @@ setup(
         "Environment :: Console :: Curses",
         "Intended Audience :: End Users/Desktop",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3 :: Only",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = style,mypy,{py35,py36,py37,py38}-tests,py39-tests-{pytz201702,pytz201610,pytz_latest}
+envlist = style,mypy,{py36,py37,py38}-tests,py39-tests-{pytz201702,pytz201610,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
I should have caught this earlier (before the release), but #1029 apparently broke py3.5 support. I guess it slipped through while we didn't have Travis.

I suspect we could work around it, but as py3.5 has been EOL for 7 months (since 2020-09-30) I propose we just stop supporting it.