### PR TITLE
Add bugbear flake8 plugin

### DIFF
--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -143,7 +143,7 @@ def get_vdirs_from_vdirsyncer_config():
               "error message:")
         print(error)
         return None
-    vdirs = list()
+    vdirs = []
     for storage in vdir_config.storages.values():
         if storage['type'] == 'filesystem':
             # TODO detect type of storage properly
@@ -152,7 +152,7 @@ def get_vdirs_from_vdirsyncer_config():
                 path += '/'
             path += '*'
             vdirs.append((storage['instance_name'], path, 'discover'))
-    if vdirs == list():
+    if vdirs == []:
         print("No usable collections were found")
         return None
     else:
@@ -162,7 +162,8 @@ def get_vdirs_from_vdirsyncer_config():
         return vdirs
 
 
-def create_vdir(names=[]):
+def create_vdir(names=None):
+    names = names or []
     if not confirm("Do you want to create a local calendar? (You can always "
                    "set it up to synchronize with a server in vdirsyncer "
                    "later)."):

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -289,7 +289,7 @@ def new_interactive(collection, calendar_name, conf, info, location=None,
             adjust_reasonably=True, localize=False,
         )
     except DateTimeParseError:
-        info = dict()
+        info = {}
 
     while True:
         summary = info.get('summary')
@@ -365,7 +365,7 @@ def new_from_args(collection, calendar_name, conf, dtstart=None, dtend=None,
                   timezone=None, url=None, format=None, env=None):
     """Create a new event from arguments and add to vdirs"""
     if isinstance(categories, str):
-        categories = list([category.strip() for category in categories.split(',')])
+        categories = [category.strip() for category in categories.split(',')]
     try:
         event = new_vevent(
             locale=conf['locale'], location=location, categories=categories,
@@ -508,7 +508,7 @@ def edit_event(event, collection, locale, allow_quit=False, width=80):
             if allow_none and value == "None":
                 value = ""
             if attr == 'categories':
-                getattr(event, "update_" + attr)(list([cat.strip() for cat in value.split(',')]))
+                getattr(event, "update_" + attr)([cat.strip() for cat in value.split(',')])
             else:
                 getattr(event, "update_" + attr)(value)
             edited = True
@@ -632,7 +632,7 @@ def print_ics(conf, name, ics, format):
     for event in events:
         events_grouped[event['UID']].append(event)
 
-    vevents = list()
+    vevents = []
     for uid in events_grouped:
         vevents.append(sorted(events_grouped[uid], key=sort_vevent_key))
 

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -504,7 +504,7 @@ class SQLiteDb(object):
             'ORDER BY dtstart')
         stuple = tuple([start, end, start, end, start, end] + list(self.calendars))
         result = self.sql_ex(sql_s.format(','.join(["?"] * len(self.calendars))), stuple)
-        for item, href, start, end, ref, etag, dtype, calendar in result:
+        for item, href, start, end, ref, etag, _dtype, calendar in result:
             start = pytz.UTC.localize(dt.datetime.utcfromtimestamp(start))
             end = pytz.UTC.localize(dt.datetime.utcfromtimestamp(end))
             yield item, href, start, end, ref, etag, calendar

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -121,7 +121,7 @@ class Event(object):
         """
         assert isinstance(events_list, list)
 
-        vevents = dict()
+        vevents = {}
         for event in events_list:
             if 'RECURRENCE-ID' in event:
                 if invalid_timezone(event['RECURRENCE-ID']):
@@ -262,21 +262,21 @@ class Event(object):
     @property
     def symbol_strings(self):
         if self._locale['unicode_symbols']:
-            return dict(
-                recurring='\N{Clockwise gapped circle arrow}',
-                range='\N{Left right arrow}',
-                range_end='\N{Rightwards arrow to bar}',
-                range_start='\N{Rightwards arrow from bar}',
-                right_arrow='\N{Rightwards arrow}'
-            )
+            return {
+                "recurring": '\N{Clockwise gapped circle arrow}',
+                "range": '\N{Left right arrow}',
+                "range_end": '\N{Rightwards arrow to bar}',
+                "range_start": '\N{Rightwards arrow from bar}',
+                "right_arrow": '\N{Rightwards arrow}'
+            }
         else:
-            return dict(
-                recurring='(R)',
-                range='<->',
-                range_end='->|',
-                range_start='|->',
-                right_arrow='->'
-            )
+            return {
+                "recurring": '(R)',
+                "range": '<->',
+                "range_end": '->|',
+                "range_start": '|->',
+                "right_arrow": '->'
+            }
 
     @property
     def start_local(self):
@@ -356,7 +356,7 @@ class Event(object):
         return text
         """
         calendar = self._create_calendar()
-        tzs = list()
+        tzs = []
         for vevent in self._vevents.values():
             if hasattr(vevent['DTSTART'].dt, 'tzinfo') and vevent['DTSTART'].dt.tzinfo is not None:
                 tzs.append(vevent['DTSTART'].dt.tzinfo)
@@ -497,12 +497,14 @@ class Event(object):
             recurstr = ''
         return recurstr
 
-    def format(self, format_string, relative_to, env={}, colors=True):
+    def format(self, format_string, relative_to, env=None, colors=True):
         """
         :param colors: determines if colors codes should be printed or not
         :type colors: bool
         """
-        attributes = dict()
+        env = env or {}
+
+        attributes = {}
         try:
             relative_to_start, relative_to_end = relative_to
         except TypeError:
@@ -680,7 +682,7 @@ class Event(object):
 
         # in case the instance we want to delete is specified as a RECURRENCE-ID
         # event, we should delete that as well
-        to_pop = list()
+        to_pop = []
         for key in self._vevents:
             if key == 'PROTO':
                 continue
@@ -853,7 +855,7 @@ def create_timezone(tz, first_date=None, last_date=None):
             last_num = num
             last_tt = transtime
 
-    timezones = dict()
+    timezones = {}
     for num in range(first_num, last_num + 1):
         name = tz._transition_info[num][2]
         if name in timezones:

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -263,19 +263,19 @@ class Event(object):
     def symbol_strings(self):
         if self._locale['unicode_symbols']:
             return {
-                "recurring": '\N{Clockwise gapped circle arrow}',
-                "range": '\N{Left right arrow}',
-                "range_end": '\N{Rightwards arrow to bar}',
-                "range_start": '\N{Rightwards arrow from bar}',
-                "right_arrow": '\N{Rightwards arrow}'
+                'recurring': '\N{Clockwise gapped circle arrow}',
+                'range': '\N{Left right arrow}',
+                'range_end': '\N{Rightwards arrow to bar}',
+                'range_start': '\N{Rightwards arrow from bar}',
+                'right_arrow': '\N{Rightwards arrow}'
             }
         else:
             return {
-                "recurring": '(R)',
-                "range": '<->',
-                "range_end": '->|',
-                "range_start": '|->',
-                "right_arrow": '->'
+                'recurring': '(R)',
+                'range': '<->',
+                'range_end': '->|',
+                'range_start': '|->',
+                'right_arrow': '->'
             }
 
     @property

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -67,14 +67,15 @@ class CalendarCollection(object):
                  color: str='',
                  priority: int=10,
                  highlight_event_days: bool=False,
-                 locale: Dict[str, Any]=dict(),
+                 locale: Dict[str, Any]=None,
                  dbpath: Optional[str]=None,
                  ) -> None:
+        locale = locale or {}
         assert dbpath is not None
         assert calendars is not None
         self._calendars = calendars
         self._default_calendar_name = None  # type: Optional[str]
-        self._storages = dict()  # type: Dict[str, Vdir]
+        self._storages = {}  # type: Dict[str, Vdir]
         for name, calendar in self._calendars.items():
             ctype = calendar.get('ctype', 'calendar')
             if ctype == 'calendar':
@@ -98,7 +99,7 @@ class CalendarCollection(object):
         self.highlight_event_days = highlight_event_days
         self._locale = locale
         self._backend = backend.SQLiteDb(self.names, dbpath, self._locale)
-        self._last_ctags = dict()  # type: Dict[str, str]
+        self._last_ctags = {}  # type: Dict[str, str]
         self.update_db()
 
     @property
@@ -303,7 +304,7 @@ class CalendarCollection(object):
     def _db_update(self, calendar: str):
         """implements the actual db update on a per calendar base"""
         local_ctag = self._local_ctag(calendar)
-        db_hrefs = set(href for href, etag in self._backend.list(calendar))
+        db_hrefs = {href for href, etag in self._backend.list(calendar)}
         storage_hrefs = set()
         bdays = self._calendars[calendar].get('ctype') == 'birthdays'
 

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -67,7 +67,7 @@ class CalendarCollection(object):
                  color: str='',
                  priority: int=10,
                  highlight_event_days: bool=False,
-                 locale: Dict[str, Any]=None,
+                 locale: Optional[Dict[str, Any]]=None,
                  dbpath: Optional[str]=None,
                  ) -> None:
         locale = locale or {}

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -357,7 +357,7 @@ class DayWalker(urwid.SimpleFocusListWalker):
         self._first_day = this_date
         self._collection = collection
 
-        super().__init__(list())
+        super().__init__([])
         self.ensure_date(this_date)
 
     def ensure_date(self, day):
@@ -470,7 +470,7 @@ class DayWalker(urwid.SimpleFocusListWalker):
 
         :type day: datetime.date
         """
-        event_list = list()
+        event_list = []
         date_header = DateHeader(
             day=day,
             dateformat=self._conf['locale']['longdateformat'],
@@ -1265,8 +1265,9 @@ def _add_calendar_colors(palette, collection):
     return palette
 
 
-def start_pane(pane, callback, program_info='', quit_keys=['q']):
+def start_pane(pane, callback, program_info='', quit_keys=None):
     """Open the user interface with the given initial pane."""
+    quit_keys = quit_keys or ['q']
 
     frame = Window(
         footer=program_info + ' | {}: quit, ?: help'.format(quit_keys[0]),
@@ -1322,7 +1323,8 @@ def start_pane(pane, callback, program_info='', quit_keys=['q']):
         frame, palette, unhandled_input=frame.on_key_press, pop_ups=True)
     frame.loop = loop
 
-    def redraw_today(loop, pane, meta={'last_today': None}):
+    def redraw_today(loop, pane, meta=None):
+        meta = meta or {'last_today': None}
         # XXX TODO this currently assumes, today moves forward by exactly one
         # day, but it could either move forward more (suspend-to-disk/ram) or
         # even move backwards

--- a/khal/ui/base.py
+++ b/khal/ui/base.py
@@ -114,7 +114,7 @@ class Pane(urwid.WidgetWrap):
             return super().keypress(size, key)
 
     def show_keybindings(self):
-        lines = list()
+        lines = []
         lines.append('  Command              Keys')
         lines.append('  =======              ====')
         for command, keys in self._conf['keybindings'].items():
@@ -144,7 +144,8 @@ class Window(urwid.Frame):
     to carry data between them.
     """
 
-    def __init__(self, footer='', quit_keys=['q']):
+    def __init__(self, footer='', quit_keys=None):
+        quit_keys = quit_keys or ['q']
         self._track = []
 
         header = urwid.AttrWrap(urwid.Text(''), 'header')

--- a/khal/ui/calendarwidget.py
+++ b/khal/ui/calendarwidget.py
@@ -485,7 +485,7 @@ class CalendarWalker(urwid.SimpleFocusListWalker):
                   if today is in this week
         :rtype: tuple(urwid.CColumns, bool)
         """
-        if self.monthdisplay == 'firstday' and 1 in [day.day for day in week]:
+        if self.monthdisplay == 'firstday' and 1 in (day.day for day in week):
             month_name = calendar.month_abbr[week[-1].month].ljust(4)
             attr = 'monthname'
         elif self.monthdisplay == 'firstfullweek' and week[0].day <= 7:
@@ -499,7 +499,7 @@ class CalendarWalker(urwid.SimpleFocusListWalker):
             attr = None
 
         this_week = [(get_month_abbr_len(), urwid.AttrMap(urwid.Text(month_name), attr))]
-        for number, day in enumerate(week):
+        for _number, day in enumerate(week):
             new_date = Date(day, self.get_styles)
             this_week.append((2, new_date))
             new_date.set_styles(self.get_styles(new_date.date, False))
@@ -543,8 +543,8 @@ class CalendarWalker(urwid.SimpleFocusListWalker):
 
         plain_weeks = calendar.Calendar(
             self.firstweekday).monthdatescalendar(year, month)
-        weeks = list()
-        for number, week in enumerate(plain_weeks):
+        weeks = []
+        for _number, week in enumerate(plain_weeks):
             week = self._construct_week(week)
             weeks.append(week)
         if clean_first_row and weeks[0][1].date.month != weeks[0][7].date.month:

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -50,8 +50,7 @@ ansi_sgr = re.compile(r'\x1b\['
 
 
 def find_last_reset(string):
-    for match in re.finditer(ansi_reset, string):
-        pass
+    *_, match = re.finditer(ansi_reset, string)
     try:
         return match.start(), match.end(), match.group(0)
     except UnboundLocalError:
@@ -59,8 +58,7 @@ def find_last_reset(string):
 
 
 def find_last_sgr(string):
-    for match in re.finditer(ansi_sgr, string):
-        pass
+    *_, match = re.finditer(ansi_sgr, string)
     try:
         return match.start(), match.end(), match.group(0)
     except UnboundLocalError:

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -50,7 +50,8 @@ ansi_sgr = re.compile(r'\x1b\['
 
 
 def find_last_reset(string):
-    *_, match = re.finditer(ansi_reset, string)
+    for match in re.finditer(ansi_reset, string):  # noqa B007: this is actually used below.
+        pass
     try:
         return match.start(), match.end(), match.group(0)
     except UnboundLocalError:
@@ -58,7 +59,8 @@ def find_last_reset(string):
 
 
 def find_last_sgr(string):
-    *_, match = re.finditer(ansi_sgr, string)
+    for match in re.finditer(ansi_sgr, string):  # noqa B007: this is actually used below.
+        pass
     try:
         return match.start(), match.end(), match.group(0)
     except UnboundLocalError:

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -22,12 +22,12 @@ def test_new_db_version():
 
 def test_event_rrule_recurrence_id():
     dbi = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert dbi.list(calname) == list()
+    assert dbi.list(calname) == []
     events = dbi.get_localized(
         BERLIN.localize(dt.datetime(2014, 6, 30, 0, 0)),
         BERLIN.localize(dt.datetime(2014, 8, 26, 0, 0)),
     )
-    assert list(events) == list()
+    assert list(events) == []
     dbi.update(_get_text('event_rrule_recuid'), href='12345.ics', etag='abcd', calendar=calname)
     assert dbi.list(calname) == [('12345.ics', 'abcd')]
     events = dbi.get_localized(
@@ -96,11 +96,11 @@ def test_event_rrule_recurrence_id_reverse():
     deal with `reverse` ordered icalendar files
     """
     dbi = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert dbi.list(calname) == list()
+    assert dbi.list(calname) == []
     events = dbi.get_localized(
         BERLIN.localize(dt.datetime(2014, 6, 30, 0, 0)),
         BERLIN.localize(dt.datetime(2014, 8, 26, 0, 0)))
-    assert list(events) == list()
+    assert list(events) == []
     dbi.update(event_rrule_recurrence_id_reverse, href='12345.ics', etag='abcd', calendar=calname)
     assert dbi.list(calname) == [('12345.ics', 'abcd')]
     events = dbi.get_localized(
@@ -184,7 +184,7 @@ def test_no_valid_timezone():
                href='12345.ics', etag='abcd', calendar=calname)
     events = dbi.get_localized(BERLIN.localize(dt.datetime(2014, 4, 9, 0, 0)),
                                BERLIN.localize(dt.datetime(2014, 4, 10, 0, 0)))
-    events = sorted(list(events))
+    events = sorted(events)
     assert len(events) == 1
     event = events[0]
     assert event[2] == BERLIN.localize(dt.datetime(2014, 4, 9, 9, 30))
@@ -193,10 +193,10 @@ def test_no_valid_timezone():
 
 def test_event_delete():
     dbi = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert dbi.list(calname) == list()
+    assert dbi.list(calname) == []
     events = dbi.get_localized(BERLIN.localize(dt.datetime(2014, 6, 30, 0, 0)),
                                BERLIN.localize(dt.datetime(2014, 8, 26, 0, 0)))
-    assert list(events) == list()
+    assert list(events) == []
     dbi.update(event_rrule_recurrence_id_reverse, href='12345.ics', etag='abcd', calendar=calname)
     assert dbi.list(calname) == [('12345.ics', 'abcd')]
     events = dbi.get_localized(BERLIN.localize(dt.datetime(2014, 6, 30, 0, 0)),
@@ -282,7 +282,7 @@ def test_event_rrule_this_and_future():
     assert events[5][3] == BERLIN.localize(dt.datetime(2014, 8, 4, 18, 0))
 
     assert 'SUMMARY:Arbeit\n' in events[0][0]
-    for num, event in enumerate(events[1:]):
+    for _num, event in enumerate(events[1:]):
         assert 'SUMMARY:Arbeit (lang)\n' in event[0]
 
 
@@ -691,7 +691,7 @@ end = dt.datetime.combine(day, dt.time.max)
 
 def test_birthdays():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 1
@@ -714,7 +714,7 @@ def test_birthdays_update():
 def test_birthdays_no_fn():
     db = backend.SQLiteDb(['home'], ':memory:', locale=LOCALE_BERLIN)
     assert list(db.get_floating(dt.datetime(1941, 9, 9, 0, 0),
-                                dt.datetime(1941, 9, 9, 23, 59, 59, 9999))) == list()
+                                dt.datetime(1941, 9, 9, 23, 59, 59, 9999))) == []
     db.update_vcf_dates(card_no_fn, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(dt.datetime(1941, 9, 9, 0, 0),
                                   dt.datetime(1941, 9, 9, 23, 59, 59, 9999)))
@@ -724,7 +724,7 @@ def test_birthdays_no_fn():
 
 def test_birthday_does_not_parse():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_does_not_parse, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 0
@@ -732,7 +732,7 @@ def test_birthday_does_not_parse():
 
 def test_vcard_two_birthdays():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_two_birthdays, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 0
@@ -740,7 +740,7 @@ def test_vcard_two_birthdays():
 
 def test_anniversary():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_anniversary, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 1
@@ -755,7 +755,7 @@ def test_anniversary():
 
 def test_abdate():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_abdate, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 1
@@ -770,7 +770,7 @@ def test_abdate():
 
 def test_abdate_nolabel():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_abdate_nolabel, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 1
@@ -785,7 +785,7 @@ def test_abdate_nolabel():
 
 def test_birthday_v3():
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
-    assert list(db.get_floating(start, end)) == list()
+    assert list(db.get_floating(start, end)) == []
     db.update_vcf_dates(card_v3, 'unix.vcf', calendar=calname)
     events = list(db.get_floating(start, end))
     assert len(events) == 1

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -320,7 +320,7 @@ def test_invalid_calendar(runner):
 def test_attach_calendar(runner):
     runner = runner(days=2)
     result = runner.invoke(main_khal, ['printcalendars'])
-    assert set(result.output.split('\n')[:3]) == {['one', 'two', 'three']}
+    assert set(result.output.split('\n')[:3]) == {'one', 'two', 'three'}
     assert not result.exception
     result = runner.invoke(main_khal, ['printcalendars', '-a', 'one'])
     assert result.output == 'one\n'

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -326,7 +326,7 @@ def test_attach_calendar(runner):
     assert result.output == 'one\n'
     assert not result.exception
     result = runner.invoke(main_khal, ['printcalendars', '-d', 'one'])
-    assert set(result.output.split('\n')[:2]) == {['two', 'three']}
+    assert set(result.output.split('\n')[:2]) == {'two', 'three'}
     assert not result.exception
 
 

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -58,7 +58,7 @@ def runner(tmpdir, monkeypatch):
             print_new=print_new,
             dbpath=str(db), **kwargs))
         runner = CustomCliRunner(
-            config_file=config_file, db=db, calendars=dict(one=calendar),
+            config_file=config_file, db=db, calendars={"one": calendar},
             xdg_data_home=xdg_data_home, xdg_config_home=xdg_config_home,
             tmpdir=tmpdir,
         )
@@ -320,13 +320,13 @@ def test_invalid_calendar(runner):
 def test_attach_calendar(runner):
     runner = runner(days=2)
     result = runner.invoke(main_khal, ['printcalendars'])
-    assert set(result.output.split('\n')[:3]) == set(['one', 'two', 'three'])
+    assert set(result.output.split('\n')[:3]) == {['one', 'two', 'three']}
     assert not result.exception
     result = runner.invoke(main_khal, ['printcalendars', '-a', 'one'])
     assert result.output == 'one\n'
     assert not result.exception
     result = runner.invoke(main_khal, ['printcalendars', '-d', 'one'])
-    assert set(result.output.split('\n')[:2]) == set(['two', 'three'])
+    assert set(result.output.split('\n')[:2]) == {['two', 'three']}
     assert not result.exception
 
 
@@ -766,7 +766,7 @@ def cleanup(paths):
     for path in paths:
         if os.path.exists(path):
             os.chmod(str(path), 0o755)
-        for dirpath, dirnames, filenames in os.walk(path):
+        for dirpath, _dirnames, filenames in os.walk(path):
             os.chmod(str(dirpath), 0o755)
             for filename in filenames:
                 os.chmod(str(os.path.join(dirpath, filename)), 0o644)

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -298,7 +298,7 @@ class TestCollection(object):
         event = Event.fromString(
             _get_text('event_dt_multi_recuid_no_master'), calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event, cal1)
-        events = list(coll.search('Event'))
+        events = sorted(coll.search('Event'))
         assert len(events) == 2
         assert events[0].format(
             '{start} {end} {title}', dt.date.today()) == '30.06. 07:30 30.06. 12:00 Arbeit\x1b[0m'
@@ -334,7 +334,7 @@ class TestCollection(object):
         event = Event.fromString(
             _get_text('invalid_tzoffset'), calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event, cal1)
-        events = list(coll.search('Event'))
+        events = sorted(coll.search('Event'))
         assert len(events) == 1
         assert events[0].format('{start} {end} {title}', dt.date.today()) == \
             '02.12. 08:00 02.12. 09:30 Some event\x1b[0m'

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -60,8 +60,8 @@ class TestCalendar(object):
 
     def test_sanity(self, coll_vdirs):
         coll, vdirs = coll_vdirs
-        mtimes = dict()
-        for i in range(100):
+        mtimes = {}
+        for _ in range(100):
             for cal in coll._calendars:
                 mtime = coll._local_ctag(cal)
                 if mtimes.get(cal):
@@ -107,10 +107,10 @@ class TestVdirsyncerCompat(object):
         event = Event.fromString(event_today, calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event)
         hrefs = sorted(href for href, etag in coll._backend.list(cal1))
-        assert set(str(coll.get_event(href, calendar=cal1).uid) for href in hrefs) == set((
+        assert {str(coll.get_event(href, calendar=cal1).uid) for href in hrefs} == {(
             'uid3@host1.com',
             'V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU',
-        ))
+        )}
 
 
 class TestCollection(object):
@@ -148,9 +148,9 @@ class TestCollection(object):
         coll, vdirs = coll_vdirs
         start = dt.datetime.combine(today, dt.time.min)
         end = dt.datetime.combine(today, dt.time.max)
-        assert list(coll.get_floating(start, end)) == list()
+        assert list(coll.get_floating(start, end)) == []
         assert list(coll.get_localized(utils.BERLIN.localize(start),
-                                       utils.BERLIN.localize(end))) == list()
+                                       utils.BERLIN.localize(end))) == []
 
     def test_insert(self, coll_vdirs):
         """insert a localized event"""
@@ -298,7 +298,7 @@ class TestCollection(object):
         event = Event.fromString(
             _get_text('event_dt_multi_recuid_no_master'), calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event, cal1)
-        events = list(sorted(coll.search('Event')))
+        events = list(coll.search('Event'))
         assert len(events) == 2
         assert events[0].format(
             '{start} {end} {title}', dt.date.today()) == '30.06. 07:30 30.06. 12:00 Arbeit\x1b[0m'
@@ -334,7 +334,7 @@ class TestCollection(object):
         event = Event.fromString(
             _get_text('invalid_tzoffset'), calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event, cal1)
-        events = list(sorted(coll.search('Event')))
+        events = list(coll.search('Event'))
         assert len(events) == 1
         assert events[0].format('{start} {end} {title}', dt.date.today()) == \
             '02.12. 08:00 02.12. 09:30 Some event\x1b[0m'
@@ -529,7 +529,7 @@ def test_birthdays(coll_vdirs_birthday):
     coll, vdirs = coll_vdirs_birthday
     assert list(
         coll.get_floating(dt.datetime(1971, 3, 11), dt.datetime(1971, 3, 11, 23, 59, 59))
-    ) == list()
+    ) == []
     vdirs[cal1].upload(DumbItem(card, 'unix'))
     coll.update_db()
     assert 'Unix\'s 41st birthday' == list(
@@ -576,7 +576,7 @@ def test_birthdays_no_year(coll_vdirs_birthday):
     coll, vdirs = coll_vdirs_birthday
     assert list(
         coll.get_floating(dt.datetime(1971, 3, 11), dt.datetime(1971, 3, 11, 23, 59, 59))
-    ) == list()
+    ) == []
     vdirs[cal1].upload(DumbItem(card_no_year, 'vcard.vcf'))
     coll.update_db()
     events = list(coll.get_floating(dt.datetime(1971, 3, 11), dt.datetime(1971, 3, 11, 23, 59, 59)))

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -107,10 +107,10 @@ class TestVdirsyncerCompat(object):
         event = Event.fromString(event_today, calendar=cal1, locale=LOCALE_BERLIN)
         coll.new(event)
         hrefs = sorted(href for href, etag in coll._backend.list(cal1))
-        assert {str(coll.get_event(href, calendar=cal1).uid) for href in hrefs} == {(
+        assert {str(coll.get_event(href, calendar=cal1).uid) for href in hrefs} == {
             'uid3@host1.com',
             'V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU',
-        )}
+        }
 
 
 class TestCollection(object):

--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,11 @@ python =
 [testenv:style]
 skip_install=True
 whitelist_externals = sh
-deps = flake8
+deps =
+  flake8
+  flake8-bugbear
 commands =
-    flake8 --ignore E252,W504,E121 tests khal setup.py
+    flake8 tests khal setup.py
     sh -c '! grep -ri seperat */*'
 
 [testenv:docs]
@@ -54,4 +56,5 @@ commands =
 
 [flake8]
 max-line-length = 100
+ignore = E252,W504,E121,B008
 exclude = .tox,examples,doc


### PR DESCRIPTION
Bugbear detects possible code issues. Like having mutable default
arguments in functions, or unnecessary calls to `list`, `set` and `dict`.

I've also moved the `flake8` ignores into the proper `tox` section. The
end result is the same when running `tox -e style`, but this change
allows code editors to pick up these settings too.