### PR TITLE
ikhal: tab moves focus from events to calendar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * DROPPED support for Python 3.5
+* CHANGE: ikhal: tab (and shift tab) jump from the events back to the calendar
 
 0.10.3
 ======

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -31,7 +31,7 @@ from .. import icalendar as icalendar_helpers, utils
 from ..khalendar.event import Event
 from ..khalendar.exceptions import ReadOnlyCalendarError
 from . import colors
-from .widgets import ExtendedEdit as Edit, NPile, NColumns, NListBox, linebox
+from .widgets import ExtendedEdit as Edit, NPile, NColumns, linebox
 from .base import Pane, Window
 from .editor import EventEditor, ExportDialog
 from .calendarwidget import CalendarWidget
@@ -555,7 +555,7 @@ class StaticDayWalker(DayWalker):
         return urwid.SimpleFocusListWalker.set_focus(self, position)
 
 
-class DateListBox(NListBox):
+class DateListBox(urwid.ListBox):
     """A ListBox container for a SimpleFocusListWalker, that contains one day
     worth of events"""
 


### PR DESCRIPTION
This commit enables tab (and shift tab) to jump from the right side
(events) to the left (calendar).  With that, we lose the ability to tab
through multiple events on one calendar day.

Tabbing through events was broken beforehand, as jumping from the first to last (or backwards) tabbing didn't work anyway.

fix #1015 

