### PR TITLE
add alarm symbol for events with at least one alarm

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * DROPPED support for Python 3.5
+* NEW Add symbol for events with at least one alarm
 
 0.10.3
 ======

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -112,6 +112,9 @@ Several options are common to almost all of :program:`khal`'s commands
    repeat-symbol
         A repeating symbol (loop arrow) if the event is repeating.
 
+   alarm-symbol
+        An alarm symbol (alarm clock) if the event has at least one alarm.
+
    location
         The event location.
 

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -264,6 +264,7 @@ class Event:
         if self._locale['unicode_symbols']:
             return dict(
                 recurring='\N{Clockwise gapped circle arrow}',
+                alarming='\N{Beamed eighth notes}',
                 range='\N{Left right arrow}',
                 range_end='\N{Rightwards arrow to bar}',
                 range_start='\N{Rightwards arrow from bar}',
@@ -272,6 +273,7 @@ class Event:
         else:
             return dict(
                 recurring='(R)',
+                alarming='(A)',
                 range='<->',
                 range_end='->|',
                 range_start='|->',
@@ -497,6 +499,14 @@ class Event:
             recurstr = ''
         return recurstr
 
+    @property
+    def _alarm_str(self):
+        if self.alarms:
+            alarmstr = ' ' + self.symbol_strings['alarming']
+        else:
+            alarmstr = ''
+        return alarmstr
+
     def format(self, format_string, relative_to, env={}, colors=True):
         """
         :param colors: determines if colors codes should be printed or not
@@ -620,6 +630,7 @@ class Event:
 
         attributes["repeat-symbol"] = self._recur_str
         attributes["repeat-pattern"] = self.recurpattern
+        attributes["alarm-symbol"] = self._alarm_str
         attributes["title"] = self.summary
         attributes["organizer"] = self.organizer.strip()
         attributes["description"] = self.description.strip()

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -273,7 +273,7 @@ bold_for_light_color = boolean(default=True)
 # ignored in `ikhal`, where events will always be shown in the color of the
 # calendar they belong to.
 # The syntax is the same as for :option:`--format`.
-agenda_event_format = string(default='{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{description-separator}{description}{reset}')
+agenda_event_format = string(default='{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{alarm-symbol}{description-separator}{description}{reset}')
 
 # Specifies how each *day header* is formatted.
 agenda_day_format = string(default='{bold}{name}, {date-long}{reset}')
@@ -288,7 +288,7 @@ monthdisplay = monthdisplay(default='firstday')
 # but :command:`list` and :command:`calendar`. It is therefore probably a
 # sensible choice to include the start- and end-date.
 # The syntax is the same as for :option:`--format`.
-event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{description-separator}{description}{reset}')
+event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{alarm-symbol}{description-separator}{description}{reset}')
 
 # When highlight_event_days is enabled, this section specifies how
 # the highlighting/coloring of days is handled.


### PR DESCRIPTION
fixes #674

Would be glad about some feedback on how you want this to be tested (if at all). Note that some tests are failing, but those are the same that have been failing before as well (platform linux -- Python 3.7.3, pytest-3.10.1, py-1.7.0, pluggy-0.8.0).

Edit: note that I chose the notes symbol because that was supported by my default font (Bitstream vera sans mono) in contrast to the other suggestions. They seem to be newer and possibly less supported.