### PR TITLE
Avoid creation of new href when UID contains unsafe character Fix #1045

### DIFF
--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -44,7 +44,7 @@ def to_bytes(x, encoding='ascii'):
 
 SAFE_UID_CHARS = ('abcdefghijklmnopqrstuvwxyz'
                   'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-                  '0123456789_.-+')
+                  '0123456789_.-+@')
 
 
 def _href_safe(uid, safe=SAFE_UID_CHARS):

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -6,6 +6,7 @@ vdirsyncer.
 import errno
 import os
 import uuid
+from hashlib import sha1
 
 from typing import Optional  # noqa
 
@@ -51,8 +52,10 @@ def _href_safe(uid, safe=SAFE_UID_CHARS):
 
 
 def _generate_href(uid=None, safe=SAFE_UID_CHARS):
-    if not uid or not _href_safe(uid, safe):
+    if not uid:
         return to_unicode(uuid.uuid4().hex)
+    elif not _href_safe(uid, safe):
+        return to_unicode(sha1(uid.encode()).hexdigest())
     else:
         return uid
 

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -57,7 +57,6 @@ def test_etag_sync(tmpdir):
     file_.write('foo')
     file_.close()
     os.sync()
-
     old_etag = vdir.get_etag_from_file(fpath)
 
     file_ = open(fpath, 'w')
@@ -86,3 +85,15 @@ def test_etag_sleep(tmpdir, sleep_time):
     new_etag = vdir.get_etag_from_file(fpath)
 
     assert old_etag != new_etag
+
+def test_get_href_from_uid ():
+    uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU@pimutils.org"
+    href = vdir._generate_href(uid)
+    assert href == "4aa4284e48c5b195d48e3f9a8fd29bd574c66f47"
+
+    uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU"
+    href = vdir._generate_href(uid)
+    assert href == "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU"
+
+    href = vdir._generate_href()
+    assert href is not None

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -88,13 +88,16 @@ def test_etag_sleep(tmpdir, sleep_time):
 
 
 def test_get_href_from_uid():
+    # Test UID with unsafe characters
+    uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWÈÉ@pimutils.org"
+    first_href = vdir._generate_href(uid)
+    second_href = vdir._generate_href(uid)
+    assert first_href == second_href
+
+    # test UID with safe characters
     uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU@pimutils.org"
     href = vdir._generate_href(uid)
-    assert href == "4aa4284e48c5b195d48e3f9a8fd29bd574c66f47"
-
-    uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU"
-    href = vdir._generate_href(uid)
-    assert href == "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU"
+    assert href == uid
 
     href = vdir._generate_href()
     assert href is not None

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -86,7 +86,8 @@ def test_etag_sleep(tmpdir, sleep_time):
 
     assert old_etag != new_etag
 
-def test_get_href_from_uid ():
+
+def test_get_href_from_uid():
     uid = "V042MJ8B3SJNFXQOJL6P53OFMHJE8Z3VZWOU@pimutils.org"
     href = vdir._generate_href(uid)
     assert href == "4aa4284e48c5b195d48e3f9a8fd29bd574c66f47"


### PR DESCRIPTION
Proposed solution is simple, if uid contain unsafe character then href is a sha1 hash of entire UID. 

Create a test for `_generate_href()` function