### PR TITLE
Remove ANSI escape codes in edit_event. Fixes #1055.

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -24,6 +24,7 @@ import datetime as dt
 import logging
 import os
 import textwrap
+import re
 from collections import OrderedDict, defaultdict
 from shutil import get_terminal_size
 
@@ -429,6 +430,7 @@ def edit_event(event, collection, locale, allow_quit=False, width=80):
     options["alarm"] = {"short": "a"}
     options["Delete"] = {"short": "D"}
     options["url"] = {"short": "u", "attr": "url", "none": True}
+    ansi = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
     now = dt.datetime.now()
 
@@ -452,7 +454,7 @@ def edit_event(event, collection, locale, allow_quit=False, width=80):
             current = event.format("{start} {end}", relative_to=now)
             value = prompt("datetime range", default=current)
             try:
-                start, end, allday = parse_datetime.guessrangefstr(value, locale)
+                start, end, allday = parse_datetime.guessrangefstr(ansi.sub('', value), locale)
                 event.update_start_end(start, end)
                 edited = True
             except:  # noqa

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -430,6 +430,10 @@ def edit_event(event, collection, locale, allow_quit=False, width=80):
     options["alarm"] = {"short": "a"}
     options["Delete"] = {"short": "D"}
     options["url"] = {"short": "u", "attr": "url", "none": True}
+    # some output contains ansi escape sequences (probably only resets)
+    # if hitting enter, the output (including the escape sequence) gets parsed
+    # and fails the parsing. Therefore we remove ansi escape sequences before
+    # parsing.
     ansi = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
     now = dt.datetime.now()

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -882,3 +882,26 @@ def test_new_interactive_extensive(runner):
     )
     assert not result.exception
     assert result.exit_code == 0
+
+
+@freeze_time('2015-6-1 8:00')
+def test_issue_1056(runner):
+    """if an ansi escape sequence is contained in the output, we can't parse it
+    properly"""
+
+    runner = runner(print_new='path', default_calendar=False)
+
+    result = runner.invoke(
+        main_khal, 'new -i'.split(),
+        'two\n'
+        'new event\n'
+        'now\n'
+        'Europe/London\n'
+        'None\n'
+        't\n'  # edit datetime range
+        '\n'
+        'n\n'
+    )
+    assert 'error parsing range' not in result.output
+    assert not result.exception
+    assert result.exit_code == 0


### PR DESCRIPTION
On testing, the problem appeared to be `\x1b[0m`, but I figured it was safer to remove all of them. There may be other places where this would be useful, but I'm not sure where.