### PR TITLE
Install type stubs and dependencies for mypy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,4 @@
+[mypy]
+ignore_missing_imports = True
+# See https://github.com/python/mypy/issues/7511:
+warn_no_return = False

--- a/tox.ini
+++ b/tox.ini
@@ -59,8 +59,3 @@ commands =
 max-line-length = 100
 ignore = E252,W504,E121,B008
 exclude = .tox,examples,doc
-
-[mypy]
-ignore_missing_imports = True
-# See https://github.com/python/mypy/issues/7511:
-warn_no_return = False

--- a/tox.ini
+++ b/tox.ini
@@ -48,13 +48,19 @@ commands =
   make -C doc man
 
 [testenv:mypy]
-skip_install=True
 whitelist_externals = sh
-deps = mypy
+deps =
+  {[testenv]deps}
+  mypy
 commands =
-    mypy --ignore-missing-imports khal
+    mypy --install-types --non-interactive {toxinidir}/khal
 
 [flake8]
 max-line-length = 100
 ignore = E252,W504,E121,B008
 exclude = .tox,examples,doc
+
+[mypy]
+ignore_missing_imports = True
+# See https://github.com/python/mypy/issues/7511:
+warn_no_return = False


### PR DESCRIPTION
mypy no longer ships type stubs and they must now be installed
separately.

Configure tox to install these for the `mypy` environment, as well as
regular dependencies (since many of these include typing hints
themselves).

I've moved `ignore_missing_imports` to a mypy-specific section, so when
mypy is run via other tools (e.g.: code editors) this settings is
applied too.