### PR TITLE
Imported events with no DTEND or DURATION will now last one hour (for DATETIME) or one day (for DATE)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,8 @@ not released
 * CHANGE ikhal: tab (and shift tab) jump from the events back to the calendar
 * NEW Add symbol for events with at least one alarm
 * FIX URL can now be set/updated from ikhal
+* FIX Imported events without an end or duration will now last one day if
+   `DTSTART` is a date (as per RFC) or one hour if it is a datetime.
 
 0.10.3
 ======

--- a/khal/icalendar.py
+++ b/khal/icalendar.py
@@ -413,8 +413,9 @@ def sanitize_timerange(dtstart, dtend, duration=None):
 
     if dtend is None and duration is None:
         if isinstance(dtstart, dt.datetime):
-            dtstart = dtstart.date()
-        dtend = dtstart + dt.timedelta(days=1)
+            dtend = dtstart + dt.timedelta(hours=1)
+        else:
+            dtend = dtstart + dt.timedelta(days=1)
     elif dtend is not None:
         if dtend < dtstart:
             raise ValueError('The event\'s end time (DTEND) is older than '
@@ -424,7 +425,10 @@ def sanitize_timerange(dtstart, dtend, duration=None):
                 "Event start time and end time are the same. "
                 "Assuming the event's duration is one hour."
             )
-            dtend += dt.timedelta(hours=1)
+            if isinstance(dtstart, dt.datetime):
+                dtend += dt.timedelta(hours=1)
+            else:
+                dtend += dt.timedelta(days=1)
 
     return dtstart, dtend
 

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -564,11 +564,13 @@ def test_no_dtend():
     """test support for events with no dtend"""
     db = backend.SQLiteDb([calname], ':memory:', locale=LOCALE_BERLIN)
     db.update(_get_text('event_dt_no_end'), href='event_dt_no_end', calendar=calname)
-    events = db.get_floating(
-        dt.datetime(2016, 1, 16, 0, 0), dt.datetime(2016, 1, 17, 0, 0))
+    events = db.get_localized(
+        BERLIN.localize(dt.datetime(2016, 1, 16, 0, 0)),
+        BERLIN.localize(dt.datetime(2016, 1, 17, 0, 0)),
+    )
     event = list(events)[0]
-    assert event[2] == dt.date(2016, 1, 16)
-    assert event[3] == dt.date(2016, 1, 17)
+    assert event[2] == BERLIN.localize(dt.datetime(2016, 1, 16, 8, 0))
+    assert event[3] == BERLIN.localize(dt.datetime(2016, 1, 16, 9, 0))
 
 
 event_rdate_period = """BEGIN:VEVENT

--- a/tests/khalendar_utils_test.py
+++ b/tests/khalendar_utils_test.py
@@ -791,8 +791,8 @@ class TestSanitize:
     def test_noend_datetime(self):
         vevent = _get_vevent(noend_datetime)
         vevent = icalendar_helpers.sanitize(vevent, berlin, '', '')
-        assert vevent['DTSTART'].dt == dt.date(2014, 8, 29)
-        assert vevent['DTEND'].dt == dt.date(2014, 8, 30)
+        assert vevent['DTSTART'].dt == BERLIN.localize(dt.datetime(2014, 8, 29, 8))
+        assert vevent['DTEND'].dt == BERLIN.localize(dt.datetime(2014, 8, 29, 9))
 
     def test_duration(self):
         vevent = _get_vevent_file('event_dtr_exdatez')


### PR DESCRIPTION
Fixes #1071