### PR TITLE
Pin to tzlocal 2.x to (temporarily) avoid zoneinfo upgrade

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     'configobj',
     # https://github.com/untitaker/python-atomicwrites/commit/4d12f23227b6a944ab1d99c507a69fdbc7c9ed6d  # noqa
     'atomicwrites>=0.1.7',
-    'tzlocal>=1.0',
+    'tzlocal>=1.0,<3',
 ]
 
 test_requirements = [


### PR DESCRIPTION
This prevents use of newer versions of tzlocal -- 3.0 replaced its own use of pytz with zoneinfo; 4.0 introduced pytz_deprecation_shim but that doesn't cover everything, as seen in #1093.  This will keep the current code working until khal switches to PEP-495.