### PR TITLE
xfail the tag_sync test as well (Fixes #1112)

### DIFF
--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -66,7 +66,12 @@ def test_etag_sync(tmpdir):
 
     new_etag = vdir.get_etag_from_file(fpath)
 
-    assert old_etag != new_etag
+    try:
+        assert old_etag != new_etag
+    except AssertionError:
+        pytest.xfail(
+            "Do we need to sleep?"
+        )
 
 
 def test_etag_sleep(tmpdir, sleep_time):

--- a/tests/vdir_test.py
+++ b/tests/vdir_test.py
@@ -27,8 +27,10 @@ import pytest
 from khal.khalendar import vdir
 
 
-@pytest.mark.xfail
-def test_etag(tmpdir):
+def test_etag(tmpdir, sleep_time):
+    if sleep_time > 0.01:
+        pytest.xfail("This environment requires sleeping")
+
     fpath = os.path.join(str(tmpdir), 'foo')
 
     file_ = open(fpath, 'w')
@@ -43,15 +45,13 @@ def test_etag(tmpdir):
 
     new_etag = vdir.get_etag_from_file(fpath)
 
-    try:
-        assert old_etag != new_etag
-    except AssertionError:
-        pytest.xfail(
-            "Do we need to sleep?"
-        )
+    assert old_etag != new_etag
 
 
-def test_etag_sync(tmpdir):
+def test_etag_sync(tmpdir, sleep_time):
+    if sleep_time > 0.01:
+        pytest.xfail("This environment requires sleeping")
+
     fpath = os.path.join(str(tmpdir), 'foo')
 
     file_ = open(fpath, 'w')
@@ -66,12 +66,7 @@ def test_etag_sync(tmpdir):
 
     new_etag = vdir.get_etag_from_file(fpath)
 
-    try:
-        assert old_etag != new_etag
-    except AssertionError:
-        pytest.xfail(
-            "Do we need to sleep?"
-        )
+    assert old_etag != new_etag
 
 
 def test_etag_sleep(tmpdir, sleep_time):


### PR DESCRIPTION
In virtualized enviroments, kvmclock provides a slightly lower time resolution than the host default tsc and therefore this test can fail on fast hosts where sync() is not adding enough wait time.