### PR TITLE
[WIP] Add preliminary support for VTODOs

### DIFF
--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -151,7 +151,7 @@ class Event:
     @classmethod
     def fromString(cls, event_str, ref=None, **kwargs):
         calendar_collection = cal_from_ics(event_str)
-        events = [item for item in calendar_collection.walk() if item.name == 'VEVENT']
+        events = [item for item in calendar_collection.walk() if item.name in ['VEVENT', 'VTODO']]
         return cls.fromVEvents(events, ref, **kwargs)
 
     def __lt__(self, other):
@@ -277,7 +277,8 @@ class Event:
                 'range': '\N{Left right arrow}',
                 'range_end': '\N{Rightwards arrow to bar}',
                 'range_start': '\N{Rightwards arrow from bar}',
-                'right_arrow': '\N{Rightwards arrow}'
+                'right_arrow': '\N{Rightwards arrow}',
+                'task': '\N{Pencil}',
             }
         else:
             return {
@@ -286,7 +287,8 @@ class Event:
                 'range': '<->',
                 'range_end': '->|',
                 'range_start': '|->',
-                'right_arrow': '->'
+                'right_arrow': '->',
+                'task': '(T)',
             }
 
     @property
@@ -303,6 +305,24 @@ class Event:
     def start(self):
         """this should return the start date(time) as saved in the event"""
         return self._start
+
+    @property
+    def task(self):
+        """this should return whether or not we are representing a task"""
+        return self._vevents[self.ref].name == 'VTODO'
+
+    @property
+    def task_status(self):
+        """nice representation of a task status"""
+        vstatus = self._vevents[self.ref].get('STATUS', 'NEEDS-ACTION')
+        status = ' '
+        if vstatus == 'COMPLETED':
+            status = 'X'
+        elif vstatus == 'IN-PROGRESS':
+            status = '/'
+        elif vstatus == 'CANCELLED':
+            status = '-'
+        return status
 
     @property
     def end(self):
@@ -427,7 +447,10 @@ class Event:
                 name=name, number=number, suffix=suffix, desc=description, leap=leap,
             )
         else:
-            return self._vevents[self.ref].get('SUMMARY', '')
+            summary = self._vevents[self.ref].get('SUMMARY', '')
+            if self.task:
+                summary = '[{state}] {summary}'.format(state=self.task_status, summary=summary)
+            return summary
 
     def update_summary(self, summary):
         self._vevents[self.ref]['SUMMARY'] = summary
@@ -515,6 +538,14 @@ class Event:
         else:
             alarmstr = ''
         return alarmstr
+
+    @property
+    def _task_str(self):
+        if self.task:
+            taskstr = ' ' + self.symbol_strings['task']
+        else:
+            taskstr = ''
+        return taskstr
 
     def format(self, format_string, relative_to, env=None, colors=True):
         """
@@ -642,6 +673,7 @@ class Event:
         attributes["repeat-symbol"] = self._recur_str
         attributes["repeat-pattern"] = self.recurpattern
         attributes["alarm-symbol"] = self._alarm_str
+        attributes["task-symbol"] = self._task_str
         attributes["title"] = self.summary
         attributes["organizer"] = self.organizer.strip()
         attributes["description"] = self.description.strip()

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -273,7 +273,7 @@ bold_for_light_color = boolean(default=True)
 # ignored in `ikhal`, where events will always be shown in the color of the
 # calendar they belong to.
 # The syntax is the same as for :option:`--format`.
-agenda_event_format = string(default='{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{alarm-symbol}{description-separator}{description}{reset}')
+agenda_event_format = string(default='{calendar-color}{cancelled}{start-end-time-style} {title}{repeat-symbol}{alarm-symbol}{task-symbol}{description-separator}{description}{reset}')
 
 # Specifies how each *day header* is formatted.
 agenda_day_format = string(default='{bold}{name}, {date-long}{reset}')
@@ -288,7 +288,7 @@ monthdisplay = monthdisplay(default='firstday')
 # but :command:`list` and :command:`calendar`. It is therefore probably a
 # sensible choice to include the start- and end-date.
 # The syntax is the same as for :option:`--format`.
-event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{alarm-symbol}{description-separator}{description}{reset}')
+event_format = string(default='{calendar-color}{cancelled}{start}-{end} {title}{repeat-symbol}{alarm-symbol}{task-symbol}{description-separator}{description}{reset}')
 
 # When highlight_event_days is enabled, this section specifies how
 # the highlighting/coloring of days is handled.


### PR DESCRIPTION
Hey, I'm evaluating `khal` and as others have mentioned, VTODOs should really be listed.

Since this is a must for me, I created a 
quick PoC that converts VTODOs to VEVENTs before adding them to the
backend, this enables us to not treat tasks as something very special.

If this approach is interesting enough, it should be forbidden that
khal edits tasks as it is out of its scope.

This would fix #448


I noticed that the sqlite3 database should be deleted in order to force `khal` to process any pre-existing VTODOs (probably just a matter of the vdir being 'up-to-date'). Don't think that's an issue.

This is the output with a recurrent meeting and a task:
```
> rm khal.db; khal list
warning: Event start time and end time are the same. Assuming the event's duration is one hour.
Today, 2022-03-17
16:00-17:00 Meeting ⟳
19:00-20:00 [ ] test task222 ✏
```

And when the task has been marked as done:
```
> todo done 1
[X] 1  32 minutes ago test task222 @CALENDAR (100%)
> khal list
Today, 2022-03-17
16:00-17:00 Meeting ⟳
19:00-20:00 [X] test task222 ✏
```