### PR TITLE
Fix tzlocal issue

### DIFF
--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -20,10 +20,12 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #
 
+import datetime as dt
 import glob
 import logging
 import os
 from os.path import expanduser, expandvars, join
+from typing import Optional
 
 import pytz
 import xdg
@@ -38,13 +40,16 @@ from .exceptions import InvalidSettingsError
 logger = logging.getLogger('khal')
 
 
-def is_timezone(tzstring):
-    """tries to convert tzstring into a pytz timezone
+def is_timezone(tzstring: Optional[str]) -> dt.tzinfo:
+    """tries to convert tzstring into a pytz timezone or return local timezone
 
     raises a VdtvalueError if tzstring is not valid
     """
     if not tzstring:
-        return get_localzone()
+        # later version of tzlocal return zoneinfo (not pytz) timezones
+        # as a lot of our other code can't deal with this yet, we need to force
+        # pytz timezones for the time being
+        return pytz.timezone(str(get_localzone()))
     try:
         return pytz.timezone(tzstring)
     except pytz.UnknownTimeZoneError:

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ requirements = [
     'configobj',
     # https://github.com/untitaker/python-atomicwrites/commit/4d12f23227b6a944ab1d99c507a69fdbc7c9ed6d  # noqa
     'atomicwrites>=0.1.7',
-    'tzlocal>=1.0,<3',
+    'tzlocal>=1.0',
 ]
 
 test_requirements = [

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -2,7 +2,7 @@ import datetime as dt
 import os.path
 
 import pytest
-from tzlocal import get_localzone
+from tzlocal import get_localzone as _get_localzone
 from validate import VdtValueError
 
 from khal.settings import get_config
@@ -15,6 +15,12 @@ from khal.settings.utils import (config_checks, get_all_vdirs,
 from .utils import LOCALE_BERLIN
 
 PATH = __file__.rsplit('/', 1)[0] + '/configs/'
+
+
+def get_localzone():
+    # this reproduces the code in settings.util for the time being
+    import pytz
+    return pytz.timezone(str(_get_localzone()))
 
 
 class TestSettings:


### PR DESCRIPTION
Newer versions of tzlocal return tzinfo timezones, not pytz ones. Khal
can't deal with tzinfo timezones for the moment, so we force pytz
timezones when we use tzlocal.

This should be removed when we completely migrate to tzinfo.

Fix #1092 #1087