### PR TITLE
Fix error logging in ikhal

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,9 @@ may want to subscribe to `GitHub's tag feed
 not released
 
 * FIX support for tzlocal >= 4.0
-* FIX ability to show event's calendar in ikhal
+* FIX ability to show an event's calendar in ikhal
+* FIX an error logging for certain broken icalendar events that made ikhal crash
+  after editing those events
 * NEW Add widget to interactive event editor that allows adding attendees as
   comma separated list of email addresses
 * FIX event creation for events after the second next DST transition

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1295,7 +1295,7 @@ def start_pane(pane, callback, program_info='', quit_keys=None):
                 return 'DEBUG'
 
         def format(self, record):
-            return (self.get_prefix(record.levelno) + ': ' + record.msg)
+            return f'{self.get_prefix(record.levelno)}: {record.msg}'
 
     class HeaderFormatter(LogPaneFormatter):
         def format(self, record):


### PR DESCRIPTION
Some invalid icalendar files would lead to error messages breaking
ikhal.

fixes #1138