### PR TITLE
Drop support for python 3.6 and 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10"]
         tox-test: ["default"]
 
     steps:

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ sphinx:
     configuration: doc/source/conf.py
 
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: doc/requirements.txt
     - method: setuptools

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,11 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
+0.11.0
+======
+not released
+
+* DROPPED support for python versions < 3.8
 
 0.10.5
 ======

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Features
 - fast and easy way to add new events
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - no support for editing the timezones of events yet
-- works with python 3.6+
+- works with python 3.8+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -17,7 +17,7 @@ Features
 - ikhal (interactive khal) lets you browse and edit calendars and events
 - only rudimentary support for creating and editing recursion rules
 - you cannot edit the timezones of events
-- works with python 3.6+
+- works with python 3.8+
 - khal should run on all major operating systems [1]_
 
 .. [1] except for Microsoft Windows

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -50,7 +50,7 @@ or better::
 
 in the unpacked distribution folder.
 
-Since version 0.10, *khal* **only supports python 3.6+**. If you have
+Since version 0.10, *khal* **only supports python 3.8+**. If you have
 python 2 and 3 installed in parallel you might need to use `pip3` instead of
 `pip` and `python3` instead of `python`. In case your operating system cannot
 deal with python 2 and 3 packages concurrently, we suggest installing *khal* in

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -50,7 +50,7 @@ or better::
 
 in the unpacked distribution folder.
 
-Since version 0.10, *khal* **only supports python 3.8+**. If you have
+Since version 0.11, *khal* **only supports python 3.8+**. If you have
 python 2 and 3 installed in parallel you might need to use `pip3` instead of
 `pip` and `python3` instead of `python`. In case your operating system cannot
 deal with python 2 and 3 packages concurrently, we suggest installing *khal* in
@@ -122,7 +122,7 @@ gained.
 Requirements
 ------------
 
-*khal* is written in python and can run on Python 3.6+. It requires a Python
+*khal* is written in python and can run on Python 3.8+. It requires a Python
 with ``sqlite3`` support enabled (which is usually the case).
 
 If you are installing python via *pip* or from source, be aware that since

--- a/setup.py
+++ b/setup.py
@@ -3,8 +3,8 @@ import sys
 
 from setuptools import setup
 
-if sys.version_info < (3, 6):
-    errstr = "khal only supports python version 3.6+. Please Upgrade.\n"
+if sys.version_info < (3, 8):
+    errstr = "khal only supports python version 3.8+. Please Upgrade.\n"
     sys.stderr.write("#" * len(errstr) + '\n')
     sys.stderr.write(errstr)
     sys.stderr.write("#" * len(errstr) + '\n')
@@ -64,8 +64,6 @@ setup(
         "Environment :: Console :: Curses",
         "Intended Audience :: End Users/Desktop",
         "Operating System :: POSIX",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py36,py37,py38,py310}-tests,py39-tests-{pytz201702,pytz201610,pytz_latest}
+envlist = {py38,py310}-tests,py39-tests-{pytz201702,pytz201610,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]
@@ -30,8 +30,6 @@ commands =
 
 [gh-actions]
 python =
-    3.6: py36
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py310


### PR DESCRIPTION
After doing final 0.10.x release, I believe we should drop python versions 3.6 and 3.7.

By now, python 3.8 has been released since > 2.5 years (released on 2019-10-14).

Ubuntu 20.04 LTS ships [python version 3.8 ](https://launchpad.net/ubuntu/+source/python3.8), we would lose support for Debian 10, but I believe that's okay.

I'd really like to move to python 3.8, mostly because this [supports typing.Protocol](https://docs.python.org/3/whatsnew/3.8.html#typing).