### PR TITLE
Fix docs building

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -18,7 +18,7 @@ import khal
 
 try:
     # Available from configobj 5.1.0
-    import configobj.validate
+    import configobj.validate as validate
 except ModuleNotFoundError:
     import validate
 


### PR DESCRIPTION
I broke this when merging a PR making khal ready for configobj 5.1 (once
that gets released) but hadn't tested building the docs.

fixes #1149