### PR TITLE
Tests for VTIMEZONE creation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ doc/source/configspec.rst
 .venv
 env/
 venv/
+.hypothesis/

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ requirements = [
 
 test_requirements = [
     'freezegun',
+    'hypothesis',
     'vdirsyncer',
 ]
 

--- a/tox.ini
+++ b/tox.ini
@@ -23,6 +23,7 @@ deps =
     python-dateutil
     pytz20187: pytz==2018.7
     pytz_latest: pytz
+    hypothesis
 
 commands =
     py.test {posargs}


### PR DESCRIPTION
More tests for #817 / #859.

As this introduces a new test dependency, we should only merge this after the 0.11.0 release.

Events that are too far into the future (after the second next DST
transition) are created with invalid VTIMEZONES.

Introduces a new test dependency: hypothesis

Reproduces #817