### PR TITLE
Remove reference to broken file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,5 +4,4 @@ include CONTRIBUTING.txt
 include AUTHORS.txt
 include COPYING
 include CHANGELOG.rst
-include misc/__khal
 include khal/settings/khal.spec


### PR DESCRIPTION
This reference makes builds fail. How did this not come up on CI?