### PR TITLE
Drop unused MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,0 @@
-include khal.conf.sample
-include README.rst
-include CONTRIBUTING.txt
-include AUTHORS.txt
-include COPYING
-include CHANGELOG.rst
-include khal/settings/khal.spec


### PR DESCRIPTION
We're using `setuptools_scm`, so git-tracked files are included
automatically. The manifest is unused.

See: https://github.com/pimutils/khal/pull/1156