### PR TITLE
ikhal: Fix deleting instances of recurring events

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ not released
 
 * DROPPED support for python versions < 3.8
 * UPDATED REQUIREMENT pytz is now required >= 2018.7
+* FIX deleting of instances of recurring events in ikhal
 * FIX if a `discover` collection is set to "readonly", discovered collections
   will now inherit the readonly property
 * NEW the `configure` command can now set up vdirsyncer

--- a/khal/icalendar.py
+++ b/khal/icalendar.py
@@ -340,7 +340,7 @@ def expand(vevent, href=''):
 
 
 def assert_only_one_uid(cal: icalendar.Calendar):
-    """assert the all VEVENTs in cal have the same UID"""
+    """assert that all VEVENTs in cal have the same UID"""
     uids = set()
     for item in cal.walk():
         if item.name == 'VEVENT':
@@ -481,10 +481,9 @@ def _get_all_properties(vevent, prop):
     return rdates
 
 
-def delete_instance(vevent: icalendar.Calendar, instance: dt.datetime) -> None:
+def delete_instance(vevent: icalendar.Event, instance: dt.datetime) -> None:
     """remove a recurrence instance from a VEVENT's RRDATE list or add it
     to the EXDATE list
-
     """
     # TODO check where this instance is coming from and only call the
     # appropriate function

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -575,6 +575,13 @@ class SQLiteDb:
         item, etag = self.sql_ex(sql_s, (href, calendar))[0]
         return item
 
+    def get_with_etag(self, href: str, calendar: str) -> Tuple[str, str]:
+        """returns the ical string and its etag matching href and calendar"""
+        assert calendar is not None
+        sql_s = 'SELECT item, etag FROM events WHERE href = ? AND calendar = ?;'
+        item, etag = self.sql_ex(sql_s, (href, calendar))[0]
+        return item, etag
+
     def search(self, search_string: str) \
             -> Iterable[Tuple[str, str, dt.date, dt.date, str, str, str]]:
         """search for events matching `search_string`"""

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -734,7 +734,7 @@ class Event:
         event._locale = self._locale
         return event
 
-    def delete_instance(self, instance):
+    def delete_instance(self, instance: str) -> None:
         """delete an instance from this event"""
         assert self.recurring
         delete_instance(self._vevents['PROTO'], instance)

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -734,8 +734,12 @@ class Event:
         event._locale = self._locale
         return event
 
-    def delete_instance(self, instance: str) -> None:
-        """delete an instance from this event"""
+    def delete_instance(self, instance: dt.datetime) -> None:
+        """delete an instance from this event
+
+        we don't check, if that instance is an instance of the recurrence rules
+        defined in the event
+        """
         assert self.recurring
         delete_instance(self._vevents['PROTO'], instance)
 

--- a/khal/khalendar/exceptions.py
+++ b/khal/khalendar/exceptions.py
@@ -41,6 +41,12 @@ class ReadOnlyCalendarError(Error):
     khal"""
 
 
+class EtagMissmatch(Error):
+
+    """An event is trying to be modified from khal which has also been externally
+    modified"""
+
+
 class OutdatedDbVersionError(FatalError):
 
     """the db file has an older version and needs to be deleted"""

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -224,9 +224,8 @@ class CalendarCollection:
 
     def get_event(self, href: str, calendar: str) -> Event:
         """get an event by its href from the datatbase"""
-        return self._construct_event(
-            self._backend.get(href, calendar), href=href, calendar=calendar,
-        )
+        event_str, etag = self._backend.get_with_etag(href, calendar)
+        return self._construct_event(event_str, etag=etag, href=href, calendar=calendar)
 
     def _construct_event(self,
                          item: str,

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -37,10 +37,11 @@ from ..custom_types import CalendarConfiguration, EventCreationTypes
 from ..icalendar import new_vevent
 from . import backend
 from .event import Event
-from .exceptions import (DuplicateUid, NonUniqueUID, ReadOnlyCalendarError,
-                         UnsupportedFeatureError, UpdateFailed)
+from .exceptions import (DuplicateUid, EtagMissmatch, NonUniqueUID,
+                         ReadOnlyCalendarError, UnsupportedFeatureError,
+                         UpdateFailed)
 from .vdir import (AlreadyExistingError, CollectionNotFoundError, Vdir,
-                   get_etag_from_file)
+                   WrongEtagError, get_etag_from_file)
 
 logger = logging.getLogger('khal')
 
@@ -216,11 +217,26 @@ class CalendarCollection:
             self._backend.update(event.raw, event.href, event.etag, calendar=calendar)
             self._backend.set_ctag(self._local_ctag(calendar), calendar=calendar)
 
-    def delete(self, href: str, etag: Optional[str], calendar: str):
+    def delete(self, href: str, etag: Optional[str], calendar: str) -> None:
+        """Delete an event specified by `href` from `calendar`"""
         if self._calendars[calendar]['readonly']:
             raise ReadOnlyCalendarError()
-        self._storages[calendar].delete(href, etag)
+        try:
+            self._storages[calendar].delete(href, etag)
+        except WrongEtagError:
+            raise EtagMissmatch()
         self._backend.delete(href, calendar=calendar)
+
+    def delete_instance(self, href: str, etag: Optional[str], calendar: str, rec_id: str) -> None:
+        """Delete a recurrence instance from an event specified by `href` from `calendar`"""
+        if self._calendars[calendar]['readonly']:
+            raise ReadOnlyCalendarError()
+        event = self.get_event(href, calendar)
+        if etag and etag != event.etag:
+            raise EtagMissmatch()
+
+        event.delete_instance(rec_id)
+        self.update(event)
 
     def get_event(self, href: str, calendar: str) -> Event:
         """get an event by its href from the datatbase"""

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -227,8 +227,16 @@ class CalendarCollection:
             raise EtagMissmatch()
         self._backend.delete(href, calendar=calendar)
 
-    def delete_instance(self, href: str, etag: Optional[str], calendar: str, rec_id: str) -> None:
-        """Delete a recurrence instance from an event specified by `href` from `calendar`"""
+    def delete_instance(self,
+                        href: str,
+                        etag: Optional[str],
+                        calendar: str,
+                        rec_id: dt.datetime,
+                        ) -> Event:
+        """Delete a recurrence instance from an event specified by `href` from `calendar`
+
+        returns the updated event
+        """
         if self._calendars[calendar]['readonly']:
             raise ReadOnlyCalendarError()
         event = self.get_event(href, calendar)
@@ -237,6 +245,7 @@ class CalendarCollection:
 
         event.delete_instance(rec_id)
         self.update(event)
+        return event
 
     def get_event(self, href: str, calendar: str) -> Event:
         """get an event by its href from the datatbase"""

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -191,9 +191,8 @@ class CalendarCollection:
             self._backend.update(event.raw, href, etag, calendar=calendar)
             self._backend.set_ctag(self._local_ctag(calendar), calendar=calendar)
 
-    def insert(self, event: Event, collection: Optional[str]=None):
+    def insert(self, event: Event, collection: Optional[str]=None) -> Event:
         """insert a new event to the vdir and the database
-
         :param event: the event that should be inserted, it will get a new href
             and etag properties
         """

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1115,9 +1115,7 @@ class ClassicView(Pane):
             self.collection.delete(href, etag, account)
         for part, rec_id in self._deleted[INSTANCES]:
             account, href, etag = part.split('\n', 2)
-            event = self.collection.get_event(href, account)
-            event.delete_instance(rec_id)
-            self.collection.update(event)
+            self.collection.delete_instance(href, etag, account, rec_id)
 
     def keypress(self, size, key):
         binds = self._conf['keybindings']

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,11 +9,11 @@ from khal.custom_types import CalendarConfiguration
 from khal.khalendar import CalendarCollection
 from khal.khalendar.vdir import Vdir
 
-from .utils import LOCALE_BERLIN, cal1, example_cals
+from .utils import LOCALE_BERLIN, CollVdirType, cal1, example_cals
 
 
 @pytest.fixture
-def coll_vdirs(tmpdir):
+def coll_vdirs(tmpdir) -> CollVdirType:
     calendars, vdirs = {}, {}
     for name in example_cals:
         path = str(tmpdir) + '/' + name

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from time import sleep
 import pytest
 import pytz
 
+from khal.custom_types import CalendarConfiguration
 from khal.khalendar import CalendarCollection
 from khal.khalendar.vdir import Vdir
 
@@ -18,8 +19,14 @@ def coll_vdirs(tmpdir):
         path = str(tmpdir) + '/' + name
         os.makedirs(path, mode=0o770)
         readonly = True if name == 'a_calendar' else False
-        calendars[name] = {'name': name, 'path': path, 'color': 'dark blue',
-                           'readonly': readonly, 'unicode_symbols': True}
+        calendars[name] = CalendarConfiguration(
+            name=name,
+            path=path,
+            readonly=readonly,
+            color='dark blue',
+            priority=10,
+            ctype='calendar',
+        )
         vdirs[name] = Vdir(path, '.ics')
     coll = CalendarCollection(calendars=calendars, dbpath=':memory:', locale=LOCALE_BERLIN)
     coll.default_calendar_name = cal1

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -214,6 +214,7 @@ class TestCollection:
         with freeze_time('2016-1-1'):
             assert normalize_component(event_from_db.raw) == \
                 normalize_component(_get_text('event_dt_simple_inkl_vtimezone'))
+        assert event_from_db.etag
 
     def test_change(self, coll_vdirs):
         """moving an event from one calendar to another"""

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,7 +1,13 @@
 import os
+from typing import Dict, Tuple
 
 import icalendar
 import pytz
+
+from khal.khalendar import CalendarCollection
+from khal.khalendar.vdir import Vdir
+
+CollVdirType = Tuple[CalendarCollection, Dict[str, Vdir]]
 
 cal0 = 'a_calendar'
 cal1 = 'foobar'


### PR DESCRIPTION
fixes #793

Todos left for further PRs:
* We probably should migrate everything to the new function `backend.get_with_etag()` or even just modify the old one.
* We are now throwing a specific error when trying to delete an event (or instance) with mismatching etags. This exception doesn't get caught and will still crash ikhal. But this is not the error from #793 and also should only occur when the vdir was externally modified while trying to delete the event from ikhal. In another PR we will catch those exceptions, inform the user and ask if we should delete anyway or cancel the deletion. 



If this is working for other people, I'll also do a "backport" and a quick 0.10.x release, as this seems rather important.