### PR TITLE
Import: print paths to events which break import

### DIFF
--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -608,7 +608,10 @@ def import_ics(collection, conf, ics, batch=False, random_uid=False, format=None
     """
     if format is None:
         format = conf['view']['event_format']
-    vevents = split_ics(ics, random_uid, conf['locale']['default_timezone'])
+    try:
+        vevents = split_ics(ics, random_uid, conf['locale']['default_timezone'])
+    except Exception as error:
+        raise FatalError(error)
     for vevent in vevents:
         import_event(vevent, collection, conf['locale'], batch, format, env)
 


### PR DESCRIPTION
This doesn't by default show the stacktrace but provides a better error
message that helps with debugging.

fix #963