### PR TITLE
Support for latest version of pytz

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ not released
 
 * DROPPED support for python versions < 3.8
 * UPDATED REQUIREMENT pytz is now required >= 2018.7
+* NEW test REQUIREMENT: packaging
+* FIX support in tests for pytz version numbers of the format year.month.minor
 * FIX deleting of instances of recurring events in ikhal
 * FIX if a `discover` collection is set to "readonly", discovered collections
   will now inherit the readonly property

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ requirements = [
 test_requirements = [
     'freezegun',
     'hypothesis',
+    'packaging',
     'vdirsyncer',
 ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,6 @@ import os
 from time import sleep
 
 import pytest
-import pytz
 
 from khal.custom_types import CalendarConfiguration
 from khal.khalendar import CalendarCollection
@@ -142,13 +141,6 @@ def sleep_time(tmpdir_factory):
         'Filesystem does not seem to save modified times of files. \n'
         'Cannot run tests that depend on this.'
     )
-
-
-@pytest.fixture(scope='session')
-def pytz_version():
-    """Return the version of pytz as a tuple."""
-    year, month = pytz.__version__.split('.')
-    return int(year), int(month)
 
 
 @pytest.fixture

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -6,6 +6,7 @@ from freezegun import freeze_time
 from hypothesis import event, given
 from hypothesis.strategies import datetimes
 from icalendar import Parameters, vCalAddress, vRecur, vText
+from packaging import version
 
 from khal.khalendar.event import (AllDayEvent, Event, FloatingEvent,
                                   LocalizedEvent, create_timezone)
@@ -341,12 +342,12 @@ def test_event_dt_long():
         '09.04.2014 09:30-12.04.2014 10:30 An Event\x1b[0m'
 
 
-def test_event_no_dst(pytz_version):
+def test_event_no_dst():
     """test the creation of a corect VTIMEZONE for timezones with no dst"""
     event_no_dst = _get_text('event_no_dst')
     cal_no_dst = _get_text('cal_no_dst')
     event = Event.fromString(event_no_dst, calendar='foobar', locale=LOCALE_BOGOTA)
-    if pytz_version > (2017, 1):
+    if version.parse(pytz.__version__) > version.Version('2017.1'):
         cal_no_dst = cal_no_dst.replace(
             'TZNAME:COT',
             'RDATE:20380118T221407\r\nTZNAME:-05'

--- a/tests/vtimezone_test.py
+++ b/tests/vtimezone_test.py
@@ -1,6 +1,7 @@
 import datetime as dt
 
 import pytz
+from packaging import version
 
 from khal.khalendar.event import create_timezone
 
@@ -63,7 +64,7 @@ def test_berlin_rdate():
     assert vberlin_dst in vberlin
 
 
-def test_bogota(pytz_version):
+def test_bogota():
     vbogota = [b'BEGIN:VTIMEZONE',
                b'TZID:America/Bogota',
                b'BEGIN:STANDARD',
@@ -74,7 +75,7 @@ def test_bogota(pytz_version):
                b'END:STANDARD',
                b'END:VTIMEZONE',
                b'']
-    if pytz_version > (2017, 1):
+    if version.parse(pytz.__version__) > version.Version('2017.1'):
         vbogota[4] = b'TZNAME:-05'
         vbogota.insert(4, b'RDATE:20380118T221407')
 


### PR DESCRIPTION
We had assumed that pytz versions would always follow the schema
year.month, but pytz 2022.2.1 broke that assumption and our code. We
should now be able to deal with pytz versions in the
year.month.anything.

fix https://github.com/pimutils/khal/issues/1180