### PR TITLE
tests working with latest pytz version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,12 @@ may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
 
+0.10.6
+======
+not released
+
+* FIX support in tests for pytz version numbers of the format year.month.minor
+
 0.10.5
 ======
 2022-06-26

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,11 @@ def sleep_time(tmpdir_factory):
 @pytest.fixture(scope='session')
 def pytz_version():
     """Return the version of pytz as a tuple."""
-    year, month = pytz.__version__.split('.')
+    split = pytz.__version__.split('.')
+    # split might have more than two elements, e.g., with pytz 2022.2.1
+    year = split[0]
+    month = split[1]
+
     return int(year), int(month)
 
 


### PR DESCRIPTION
We had assumed that pytz versions would always follow the schema
year.month, but pytz 2022.2.1 broke that assumption and our code. We
should now be able to deal with pytz versions in the
year.month.anything.

fix #1180