### PR TITLE
Using floating numbers for Time Differences

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,7 +22,7 @@ repos:
           - flake8-bugbear
         exclude: doc/source/conf.py
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.38.0
+    rev: v2.38.2
     hooks:
     -   id: pyupgrade
         args: [--py36-plus]

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -47,3 +47,4 @@ Fred Thomsen - me [at] fredthomsen [dot] net - http://fredthomsen.net
 Robin Schubert
 Axel Gschaider - axel.gschaider [at] posteo [dot] de
 Anuragh - kpanuragh [at] gmail [dot] com
+Daniel James Perry - dperry45 [at] gatech [dot] edu

--- a/khal/parse_datetime.py
+++ b/khal/parse_datetime.py
@@ -291,7 +291,7 @@ def guesstimedeltafstr(delta_string: str) -> dt.timedelta:
     :rtype: datetime.timedelta
     """
 
-    tups = re.split(r'(-?\d+)', delta_string)
+    tups = re.split(r'(-?\d+\.?\d*)', delta_string)
     if not re.match(r'^\s*$', tups[0]):
         raise ValueError('Invalid beginning of timedelta string "%s": "%s"'
                          % (delta_string, tups[0]))
@@ -300,22 +300,22 @@ def guesstimedeltafstr(delta_string: str) -> dt.timedelta:
 
     for num, unit in zip(tups[0::2], tups[1::2]):
         try:
-            numint = int(num)
+            numfloat = float(num)
         except ValueError:
             raise DateTimeParseError(
                 f'Invalid number in timedelta string "{delta_string}": "{num}"')
 
         ulower = unit.lower().strip()
         if ulower == 'd' or ulower == 'day' or ulower == 'days':
-            res += dt.timedelta(days=numint)
+            res += dt.timedelta(days=numfloat)
         elif ulower == 'h' or ulower == 'hour' or ulower == 'hours':
-            res += dt.timedelta(hours=numint)
+            res += dt.timedelta(hours=numfloat)
         elif (ulower == 'm' or ulower == 'minute' or ulower == 'minutes' or
               ulower == 'min'):
-            res += dt.timedelta(minutes=numint)
+            res += dt.timedelta(minutes=numfloat)
         elif (ulower == 's' or ulower == 'second' or ulower == 'seconds' or
               ulower == 'sec'):
-            res += dt.timedelta(seconds=numint)
+            res += dt.timedelta(seconds=numfloat)
         else:
             raise ValueError('Invalid unit in timedelta string "%s": "%s"'
                              % (delta_string, unit))

--- a/tests/parse_datetime_test.py
+++ b/tests/parse_datetime_test.py
@@ -183,6 +183,9 @@ class TestGuessTimedeltafstr:
     def test_seconds(self):
         assert dt.timedelta(seconds=10) == guesstimedeltafstr('10s')
 
+    def test_decimal(self):
+        assert dt.timedelta(hours=1.5) == guesstimedeltafstr('1.5h')
+
     def test_negative(self):
         assert dt.timedelta(minutes=-10) == guesstimedeltafstr('-10m')
 


### PR DESCRIPTION
Python's `timedelta` class can accept floating point numbers as fields, so why restrict ourselves to integers?
This commit was spurred by attempting `khal new <datetime> 2.5h <summary>` and seeing it failed.