### PR TITLE
Do not evaluate etag when deleting instances

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1115,7 +1115,7 @@ class ClassicView(Pane):
             self.collection.delete(href, etag, account)
         for part, rec_id in self._deleted[INSTANCES]:
             account, href, etag = part.split('\n', 2)
-            self.collection.delete_instance(href, etag, account, rec_id)
+            self.collection.delete_instance(href, None, account, rec_id)
 
     def keypress(self, size, key):
         binds = self._conf['keybindings']


### PR DESCRIPTION
If multiple instances of an event are deleted one after the other, the event will be updated each time and thus its etag will change dynamically each time.
This will lead to a mismatch with the static etag recorded at the time when the instances are queued for deletion.

Instead of overcomplicating things by re-adjusting the deletion queue each time, do not pass the static etag so that it will not be evaluated (delete_instance function for the collection, see khalendar.py:229, i.e. do not trigger etag matching in khalendar.py:242).