### PR TITLE
Do not evaluate etag when deleting instances

### DIFF
--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -242,9 +242,6 @@ class CalendarCollection:
         if self._calendars[calendar]['readonly']:
             raise ReadOnlyCalendarError()
         event = self.get_event(href, calendar)
-        if etag and etag != event.etag:
-            raise EtagMissmatch()
-
         event.delete_instance(rec_id)
         self.update(event)
         return event

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -243,9 +243,6 @@ class VdirBase:
         fpath = self._get_filepath(href)
         if not os.path.exists(fpath):
             raise NotFoundError(item.uid)
-        actual_etag = get_etag_from_file(fpath)
-        if etag != actual_etag:
-            raise WrongEtagError(etag, actual_etag)
 
         if not isinstance(item.raw, str):
             raise TypeError('item.raw must be a unicode string.')


### PR DESCRIPTION
If multiple instances of an event are deleted one after the other, the event will be updated each time and thus its etag will change dynamically each time. This will lead to a mismatch with the static etag recorded at the time when the instances are queued for deletion.

Instead of re-adjusting the deletion queue each time, do not compare the dynamic etag with the static etag. The etag for the event will be updated anyway.