### PR TITLE
[WIP] Adding export command to khal CLI

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -633,6 +633,37 @@ def _get_cli():
 
     @cli.command()
     @multi_calendar_option
+    @click.option('--show-past', help=('Include events that have already occurred in the search'),
+                  is_flag=True)
+    @click.option('--export-ics', '-e',
+                  type=click.File('w'),
+                  default='-',
+                  metavar='FILE',
+                  help=('The file name to export the events into. Use "-" to output to stdout.'))
+    @click.argument('search_string', nargs=-1)
+    @click.pass_context
+
+    def export(ctx, search_string, export_ics, show_past, include_calendar, exclude_calendar):
+        '''Export events matching the search string. Prints to stdout by default.'''
+        try:
+            controllers.export(
+                build_collection(
+                    ctx.obj['conf'],
+                    multi_calendar_select(ctx, include_calendar, exclude_calendar)
+                ),
+                ' '.join(search_string),
+                export_ics,
+                allow_past=show_past,
+                locale=ctx.obj['conf']['locale'],
+                conf=ctx.obj['conf']
+            )
+        except FatalError as error:
+            logger.debug(error, exc_info=True)
+            logger.fatal(error)
+            sys.exit(1)
+
+    @cli.command()
+    @multi_calendar_option
     @click.option('--format', '-f',
                   help=('The format of the events.'))
     @click.option('--day-format', '-df',

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -642,7 +642,6 @@ def _get_cli():
                   help=('The file name to export the events into. Use "-" to output to stdout.'))
     @click.argument('search_string', nargs=-1)
     @click.pass_context
-
     def export(ctx, search_string, export_ics, show_past, include_calendar, exclude_calendar):
         '''Export events matching the search string. Prints to stdout by default.'''
         try:

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -584,6 +584,7 @@ def edit(collection, search_string, locale, format=None, allow_past=False, conf=
         if not edit_event(event, collection, locale, allow_quit=True, width=term_width):
             return
 
+
 def export(collection, search_string, export_ics, locale, allow_past=False, conf=None):
     now = conf['locale']['local_timezone'].localize(dt.datetime.now())
 
@@ -591,8 +592,8 @@ def export(collection, search_string, export_ics, locale, allow_past=False, conf
     exported = []
     if events:
         sl = events[0].raw.split('\n')
-        header = '\n'.join(sl[:3]) + '\n' # 3 first lines of first event
-        footer = '\n'.join(sl[-2:]) # last line of first event
+        header = '\n'.join(sl[:3]) + '\n'  # 3 first lines of first event
+        footer = '\n'.join(sl[-2:])  # last line of first event
         export_ics.write(header)
         for event in events:
             if not allow_past:
@@ -600,7 +601,7 @@ def export(collection, search_string, export_ics, locale, allow_past=False, conf
                     continue
                 elif not event.allday and event.end_local < now:
                     continue
-              # skip repeated events already exported
+            # skip repeated events already exported
             if event.uid in exported:
                 continue
             else:
@@ -610,6 +611,7 @@ def export(collection, search_string, export_ics, locale, allow_past=False, conf
         export_ics.write(footer)
     if not export_ics.name == "<stdout>":
         echo('Exported {} events to output file "{}"'.format(len(exported), export_ics.name))
+
 
 def interactive(collection, conf):
     """start the interactive user interface"""


### PR DESCRIPTION
This PR adds an export command to the command line interface of khal. It takes inspiration from PR #839 but uses the same search interface as the 'edit' command. Searches for a specific UID are therefore possible which addresses issue #892. Similarly, dates and date ranges are possible.

Default is output to `stdout` but output to file is possible via an option. Some examples:
```
$ ./khal export SC-d8769c25-d1ad-4067-b093-0c35ff5c488e
BEGIN:VCALENDAR
VERSION:2.0
PRODID:-//PIMUTILS.ORG//NONSGML khal / icalendar //EN
BEGIN:VEVENT
SUMMARY:EmacsConf 2022
DTSTART;VALUE=DATE:20221203
DTEND;VALUE=DATE:20221205
DTSTAMP:20220722T191339Z
UID:SC-d8769c25-d1ad-4067-b093-0c35ff5c488e
CATEGORIES:event
END:VEVENT
END:VCALENDAR
```

Saving instead to file:
```
$ ./khal export --export-ics khal_export.ics SC-d8769c25-d1ad-4067-b093-0c35ff5c488e
Exported 1 events to output file "khal_export.ics"
```

This is a WIP as I would like to get some feedback for the approach before going into documentation and tests. I believe that everything discussed in #839 is covered here.

My main concern, however, is handling of repeated events as I am only starting to understand how they work. This approach is not ideal if one specifically wants a given UID: all occurrences of an event are collected before only one is used to retrieve the "raw" ics. From my tests and reading the code, I **believe** that it does not matter from which of the repeated UIDs I take the raw ics but it would be good to have that confirmed :)

Left to do (from my side):
- [ ] Add documentation
- [ ] Run tests
- [ ] Add tests
- [ ] Add to `CHANGELOG.rst`
- [ ] Add to `AUTHORS.txt`  