### PR TITLE
Import only xdg from settings.py

### DIFF
--- a/khal/settings/settings.py
+++ b/khal/settings/settings.py
@@ -23,7 +23,7 @@
 import logging
 import os
 
-import xdg.BaseDirectory
+import xdg
 from configobj import (ConfigObj, ConfigObjError, flatten_errors,
                        get_extra_values)
 


### PR DESCRIPTION
The line `import xdg.BaseDirectory` can fail if there is no such module.

I'm using khal, version 0.10.5, from the Arch community repos.

The change doesn't seem notable enough for extra changes in `AUTHORS.txt`, or `CHANGELOG.rst`.