### PR TITLE
Specify unit of measurement for timedelta option

### DIFF
--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -28,5 +28,5 @@ monthdisplay = firstday
 
 [default]
 default_calendar = home
-timedelta = 2 # the default timedelta that list uses
+timedelta = 2d # the default timedelta that list uses
 highlight_event_days = True  # the default is False


### PR DESCRIPTION
If the unit of measurement is missing an error is displayed to the user, for example:
```
❯ khal list
critical: config error:
critical: in [default] timedelta: the value "Invalid timedelta: 2" is unacceptable.
If your configuration file used to work, please have a look at the Changelog to see what changed.
```