### PR TITLE
Use Ruff for code linting and checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,19 +13,6 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
-  - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies:
-          - flake8-comprehensions
-          - flake8-bugbear
-        exclude: doc/source/conf.py
-  - repo: https://github.com/asottile/pyupgrade
-    rev: v3.3.1
-    hooks:
-    -   id: pyupgrade
-        args: [--py36-plus]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:
@@ -37,3 +24,8 @@ repos:
           - types-pytz
           - types-setuptools
           - types-python-dateutil
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: 'v0.0.244'
+    hooks:
+      - id: ruff
+        args: ["--fix"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
       - id: check-toml
       - id: check-added-large-files
       - id: debug-statements
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
-    hooks:
-      - id: isort
-        name: isort (python)
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.0.0
     hooks:

--- a/doc/source/hacking.rst
+++ b/doc/source/hacking.rst
@@ -127,7 +127,7 @@ Code Style
 khal's source code should adhere to the rules laid out in :pep:`008`, except
 for allowing line lengths of up to 100 characters if it improves
 overall legibility (use your judgement).  This can be checked by installing and
-running flake8_ (run with :command:`flake8` from khal's source directory), which
+running ruff_ (run with :command:`ruff` from khal's source directory), which
 will also be run with tox and GitHub Actions, see section above.
 
 We try to document the parameters functions and methods accept, including their
@@ -148,7 +148,7 @@ identifiers, e.g., in dictionary keys::
 .. _tox: https://tox.readthedocs.org/
 .. _pytest: http://pytest.org/
 .. _pytest-cov: https://pypi.python.org/pypi/pytest-cov
-.. _flake8: http://flake8.pycqa.org/
+.. _ruff: https://github.com/charliermarsh/ruff
 .. _sphinx: http://www.sphinx-doc.org
 .. _restructuredtext: http://www.sphinx-doc.org/en/1.5.1/rest.html
 .. _ipdb: https://pypi.python.org/pypi/ipdb

--- a/khal/configwizard.py
+++ b/khal/configwizard.py
@@ -26,8 +26,7 @@ import logging
 from functools import partial
 from itertools import zip_longest
 from os import environ, makedirs
-from os.path import (dirname, exists, expanduser, expandvars, isdir, join,
-                     normpath)
+from os.path import dirname, exists, expanduser, expandvars, isdir, join, normpath
 from subprocess import call
 
 import xdg

--- a/khal/controllers.py
+++ b/khal/controllers.py
@@ -32,8 +32,7 @@ from typing import List, Optional
 import pytz
 from click import confirm, echo, prompt, style
 
-from khal import (__productname__, __version__, calendar_display,
-                  parse_datetime, utils)
+from khal import __productname__, __version__, calendar_display, parse_datetime, utils
 from khal.custom_types import EventCreationTypes, LocaleConfiguration
 from khal.exceptions import DateTimeParseError, FatalError
 from khal.khalendar import CalendarCollection
@@ -41,9 +40,8 @@ from khal.khalendar.event import Event
 from khal.khalendar.exceptions import DuplicateUid, ReadOnlyCalendarError
 
 from .exceptions import ConfigurationError
-from .icalendar import cal_from_ics
+from .icalendar import cal_from_ics, split_ics
 from .icalendar import sort_key as sort_vevent_key
-from .icalendar import split_ics
 from .khalendar.vdir import Item
 from .terminal import merge_columns
 

--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -41,8 +41,7 @@ from ..icalendar import assert_only_one_uid, cal_from_ics
 from ..icalendar import expand as expand_vevent
 from ..icalendar import sanitize as sanitize_vevent
 from ..icalendar import sort_key as sort_vevent_key
-from .exceptions import (CouldNotCreateDbDir, NonUniqueUID,
-                         OutdatedDbVersionError, UpdateFailed)
+from .exceptions import CouldNotCreateDbDir, NonUniqueUID, OutdatedDbVersionError, UpdateFailed
 
 logger = logging.getLogger('khal')
 

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -209,7 +209,7 @@ class Event:
 
         beware, this methods performs some open heart surgery
         """
-        if type(start) != type(end):  # flake8: noqa
+        if type(start) != type(end):
             raise ValueError('DTSTART and DTEND should be of the same type (datetime or date)')
         self.__class__ = self._get_type_from_date(start)
 

--- a/khal/khalendar/khalendar.py
+++ b/khal/khalendar/khalendar.py
@@ -30,18 +30,27 @@ import itertools
 import logging
 import os
 import os.path
-from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple,  # noqa
-                    Union)
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union  # noqa
 
 from ..custom_types import CalendarConfiguration, EventCreationTypes
 from ..icalendar import new_vevent
 from . import backend
 from .event import Event
-from .exceptions import (DuplicateUid, EtagMissmatch, NonUniqueUID,
-                         ReadOnlyCalendarError, UnsupportedFeatureError,
-                         UpdateFailed)
-from .vdir import (AlreadyExistingError, CollectionNotFoundError, Vdir,
-                   WrongEtagError, get_etag_from_file)
+from .exceptions import (
+    DuplicateUid,
+    EtagMissmatch,
+    NonUniqueUID,
+    ReadOnlyCalendarError,
+    UnsupportedFeatureError,
+    UpdateFailed,
+)
+from .vdir import (
+    AlreadyExistingError,
+    CollectionNotFoundError,
+    Vdir,
+    WrongEtagError,
+    get_etag_from_file,
+)
 
 logger = logging.getLogger('khal')
 

--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -7,8 +7,7 @@ import errno
 import os
 import uuid
 from hashlib import sha1
-from typing import (IO, Callable, Dict, Iterable, Optional, Protocol, Tuple,
-                    Type)
+from typing import IO, Callable, Dict, Iterable, Optional, Protocol, Tuple, Type
 
 from atomicwrites import atomic_write
 

--- a/khal/settings/settings.py
+++ b/khal/settings/settings.py
@@ -24,8 +24,7 @@ import logging
 import os
 
 import xdg.BaseDirectory
-from configobj import (ConfigObj, ConfigObjError, flatten_errors,
-                       get_extra_values)
+from configobj import ConfigObj, ConfigObjError, flatten_errors, get_extra_values
 
 from khal import __productname__
 
@@ -37,11 +36,19 @@ except ModuleNotFoundError:
 
 from typing import Callable, List, Optional
 
-from .exceptions import (CannotParseConfigFileError, InvalidSettingsError,
-                         NoConfigFile)
-from .utils import (config_checks, expand_db_path, expand_path,
-                    get_color_from_vdir, get_vdir_type, is_color, is_timedelta,
-                    is_timezone, monthdisplay_option, weeknumber_option)
+from .exceptions import CannotParseConfigFileError, InvalidSettingsError, NoConfigFile
+from .utils import (
+    config_checks,
+    expand_db_path,
+    expand_path,
+    get_color_from_vdir,
+    get_vdir_type,
+    is_color,
+    is_timedelta,
+    is_timezone,
+    monthdisplay_option,
+    weeknumber_option,
+)
 
 logger = logging.getLogger('khal')
 SPECPATH = os.path.join(os.path.dirname(__file__), 'khal.spec')

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -33,9 +33,8 @@ from ..khalendar.exceptions import ReadOnlyCalendarError
 from . import colors
 from .base import Pane, Window
 from .editor import EventEditor, ExportDialog
-from .widgets import CalendarWidget
+from .widgets import CalendarWidget, NColumns, NPile, linebox
 from .widgets import ExtendedEdit as Edit
-from .widgets import NColumns, NPile, linebox
 
 logger = logging.getLogger('khal')
 

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -24,10 +24,20 @@ import datetime as dt
 import urwid
 
 from ..utils import get_weekday_occurrence, get_wrapped_text
-from .widgets import (AlarmsEditor, CalendarWidget, Choice,
-                      DateConversionError, DateWidget, ExtendedEdit, NColumns,
-                      NListBox, NPile, PositiveIntEdit, TimeWidget,
-                      ValidatedEdit)
+from .widgets import (
+    AlarmsEditor,
+    CalendarWidget,
+    Choice,
+    DateConversionError,
+    DateWidget,
+    ExtendedEdit,
+    NColumns,
+    NListBox,
+    NPile,
+    PositiveIntEdit,
+    TimeWidget,
+    ValidatedEdit,
+)
 
 
 class StartEnd:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-select = ["E", "F", "W", "B0", "UP", "C4"]
+select = ["E", "F", "W", "I", "B0", "UP", "C4"]
 ignore = ["B008"]
 line-length = 100
 target-version = "py38"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.ruff]
+select = ["E", "F", "W", "B0", "UP", "C4"]
+ignore = ["B008"]
+line-length = 100
+target-version = "py38"

--- a/tests/cal_display_test.py
+++ b/tests/cal_display_test.py
@@ -5,8 +5,13 @@ import unicodedata
 
 import pytest
 
-from khal.calendar_display import (get_calendar_color, get_color_list,
-                                   getweeknumber, str_week, vertical_month)
+from khal.calendar_display import (
+    get_calendar_color,
+    get_color_list,
+    getweeknumber,
+    str_week,
+    vertical_month,
+)
 
 today = dt.date.today()
 yesterday = today - dt.timedelta(days=1)

--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -8,11 +8,19 @@ from hypothesis.strategies import datetimes
 from icalendar import Parameters, vCalAddress, vRecur, vText
 from packaging import version
 
-from khal.khalendar.event import (AllDayEvent, Event, FloatingEvent,
-                                  LocalizedEvent, create_timezone)
+from khal.khalendar.event import AllDayEvent, Event, FloatingEvent, LocalizedEvent, create_timezone
 
-from .utils import (BERLIN, BOGOTA, GMTPLUS3, LOCALE_BERLIN, LOCALE_BOGOTA,
-                    LOCALE_MIXED, NEW_YORK, _get_text, normalize_component)
+from .utils import (
+    BERLIN,
+    BOGOTA,
+    GMTPLUS3,
+    LOCALE_BERLIN,
+    LOCALE_BOGOTA,
+    LOCALE_MIXED,
+    NEW_YORK,
+    _get_text,
+    normalize_component,
+)
 
 EVENT_KWARGS = {'calendar': 'foobar', 'locale': LOCALE_BERLIN}
 

--- a/tests/khalendar_test.py
+++ b/tests/khalendar_test.py
@@ -16,9 +16,20 @@ from khal.khalendar.event import Event
 from khal.khalendar.vdir import Item
 
 from . import utils
-from .utils import (BERLIN, LOCALE_BERLIN, LOCALE_SYDNEY, LONDON, SYDNEY,
-                    CollVdirType, DumbItem, _get_text, cal1, cal2, cal3,
-                    normalize_component)
+from .utils import (
+    BERLIN,
+    LOCALE_BERLIN,
+    LOCALE_SYDNEY,
+    LONDON,
+    SYDNEY,
+    CollVdirType,
+    DumbItem,
+    _get_text,
+    cal1,
+    cal2,
+    cal3,
+    normalize_component,
+)
 
 today = dt.date.today()
 yesterday = today - dt.timedelta(days=1)

--- a/tests/parse_datetime_test.py
+++ b/tests/parse_datetime_test.py
@@ -6,13 +6,23 @@ from freezegun import freeze_time
 
 from khal.exceptions import DateTimeParseError, FatalError
 from khal.icalendar import new_vevent
-from khal.parse_datetime import (construct_daynames, eventinfofstr,
-                                 guessdatetimefstr, guessrangefstr,
-                                 guesstimedeltafstr, timedelta2str,
-                                 weekdaypstr)
+from khal.parse_datetime import (
+    construct_daynames,
+    eventinfofstr,
+    guessdatetimefstr,
+    guessrangefstr,
+    guesstimedeltafstr,
+    timedelta2str,
+    weekdaypstr,
+)
 
-from .utils import (LOCALE_BERLIN, LOCALE_FLOATING, LOCALE_NEW_YORK,
-                    _replace_uid, normalize_component)
+from .utils import (
+    LOCALE_BERLIN,
+    LOCALE_FLOATING,
+    LOCALE_NEW_YORK,
+    _replace_uid,
+    normalize_component,
+)
 
 
 def _create_testcases(*cases):

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -5,11 +5,14 @@ import pytest
 from tzlocal import get_localzone as _get_localzone
 
 from khal.settings import get_config
-from khal.settings.exceptions import (CannotParseConfigFileError,
-                                      InvalidSettingsError)
-from khal.settings.utils import (config_checks, get_all_vdirs,
-                                 get_color_from_vdir, get_unique_name,
-                                 is_color)
+from khal.settings.exceptions import CannotParseConfigFileError, InvalidSettingsError
+from khal.settings.utils import (
+    config_checks,
+    get_all_vdirs,
+    get_color_from_vdir,
+    get_unique_name,
+    is_color,
+)
 
 try:
     # Available from configobj 5.1.0

--- a/tox.ini
+++ b/tox.ini
@@ -42,14 +42,6 @@ commands =
   make -C doc html
   make -C doc man
 
-[flake8]
-max-line-length = 100
-ignore = E252,W504,E121,B008
-exclude = .tox,examples,doc
-extend-ignore =
-  # Line jump before binary operator.
-  W503,
-
 [mypy]
 # Silence warnings given by using untyped libraries:
 ignore_missing_imports = True


### PR DESCRIPTION
[Ruff](https://github.com/charliermarsh/ruff) does the same as flake8(+plugins)+pyupgrade+isort, but much faster and can also automatically fix many of these quirks too.

It ignores all files that are ignored by git, so all the exclude rules are not necessary.

I have left isort-related rules out for now since they results in some changes which might add noise at this point.