### PR TITLE
Run testting for python 3.11 in tox too

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py310}-tests,py39-tests-{pytz2018.7,pytz_latest}
+envlist = {py38,py310,py311}-tests,py39-tests-{pytz2018.7,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
python 3.11 was activated only in the github-workflow, not in tox when running manually.