### PR TITLE
Propagate rename of collection to calendar_name introduced in 1a262b4

### DIFF
--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -749,7 +749,7 @@ class EventColumn(urwid.WidgetWrap):
             new_event = self.pane.collection.create_event_from_ics(
                 ics,
                 etag=event.etag,
-                collection=event.calendar,
+                calendar_name=event.calendar,
                 href=event.href,
             )
             self.pane.collection.update(new_event)


### PR DESCRIPTION
This should fix #1235 by propagating the rename of `collection` to `calendar_name` in `Calendar.Collection.create_event_from_ics`, introduced in 1a262b4.