### PR TITLE
Fix duplicate event from ikhal

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -49,3 +49,4 @@ Axel Gschaider - axel.gschaider [at] posteo [dot] de
 Anuragh - kpanuragh [at] gmail [dot] com
 Henning Ullrich - github {at] henning-ullrich [dot] de
 Jason Cox - me [at] jasoncarloscox [dot] com - https://jasoncarloscox.com
+Michael Tretter - michael.tretter [at] posteo [dot] net

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ may want to subscribe to `GitHub's tag feed
 not released yet
 
 * FIX khal `at` also uses `event_format` not `agenda_event_format`
+* FIX duplicating an event using `p` in ikhal
 
 0.11.1
 ======

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -848,7 +848,7 @@ class EventColumn(urwid.WidgetWrap):
         # up on disk but not be displayed in khal
         event = self.focus_event.event.duplicate()
         try:
-            self.pane.collection.new(event)
+            self.pane.collection.insert(event)
         except ReadOnlyCalendarError:
             event.calendar = self.pane.collection.default_calendar_name or \
                 self.pane.collection.writable_names[0]


### PR DESCRIPTION
Commit f7fd70bb ("CalendarCollection.new() -> CalendarCollection.insert()") broke duplicating an event from ikhal using "p". Follow the function rename to fix it.