### PR TITLE
Use vermin to check Python-compat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     hooks:
       - id: ruff
         args: ["--fix"]
+  - repo: https://github.com/netromdk/vermin
+    rev: 58fe25f0a3bdaeefe7a2a021bee2938f5465ccde
+    hooks:
+      - id: vermin
+        args: ['-t=3.8-', '--violations']


### PR DESCRIPTION
Vermin checks source code for anything that might be incompatible with older Python versions.

This prevents accidentally using a feature from Python 3.10 when we're still supporting 3.8.

While tests ideally detect this, there will always be some bits not covered by tests.

Using a non-release revision since we need some unreleased changes to deal with zoneinfo backports.

See: https://github.com/netromdk/vermin/issues/189