### PR TITLE
ikhal: initial support for config based ikhal theming

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ not released yet
 * optimization in ikhal when editing events in the far future or past
 * FIX an issue in ikhal with updating the view of the event list after editing
   an event
+* NEW properties of ikhal themes (dark and light) can now be overriden from the
+  config file (via the new [palette] section, check the documenation)
 
 0.11.2
 ======

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -324,3 +324,21 @@ multiple_on_overflow = boolean(default=False)
 # actually disables highlighting for events that should use the
 # default color.
 default_color = color(default='')
+
+# Override ikhal's color theme with a custom palette. This is useful to style
+# certain elements of ikhal individually.
+# Palette entries take the form of `key = foreground, background, mono,
+# foreground_high, background_high` where foreground and background are used in
+# "low color mode"  and foreground_high and background_high are used in "high
+# color mode" and mono if only monocolor is supported. If you don't want to set
+# a value for a certain color, use an empty string (`''`).
+# Valid entries for low color mode are listed on the urwid website_.
+# _http://urwid.org/manual/displayattributes.html#standard-foreground-colors For
+# high color mode you can use any valid 24-bit color value, e.g. `'#ff0000'`.
+# NOTE: 24-bit colors must be enclosed in single quotes to be parsed correctly,
+# otherwise the `#` will be interpreted as a comment.
+# Most modern terminals should support high color mode.
+# Example entry: `header = light red, default, default, #ff0000, default`
+# See the default palettes in `khal/ui/colors.py` for all available keys.
+# If you can't theme an element in ikhal, please open an issue on github.
+[palette]

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -257,7 +257,7 @@ blank_line_before_day = boolean(default=False)
 # `khal/settings/khal.spec` in the section `[default]` of the property `theme`.
 #
 # __ http://urwid.org/manual/displayattributes.html
-# .. _github: # https://github.com/pimutils/khal/issues
+# .. _github: https://github.com/pimutils/khal/issues
 theme = option('dark', 'light', default='dark')
 
 # Whether to show a visible frame (with *box drawing* characters) around some
@@ -332,13 +332,28 @@ default_color = color(default='')
 # "low color mode"  and foreground_high and background_high are used in "high
 # color mode" and mono if only monocolor is supported. If you don't want to set
 # a value for a certain color, use an empty string (`''`).
-# Valid entries for low color mode are listed on the urwid website_.
-# _http://urwid.org/manual/displayattributes.html#standard-foreground-colors For
+# Valid entries for low color mode are listed on the `urwid website
+# <http://urwid.org/manual/displayattributes.html#standard-foreground-colors>`_. For
 # high color mode you can use any valid 24-bit color value, e.g. `'#ff0000'`.
-# NOTE: 24-bit colors must be enclosed in single quotes to be parsed correctly,
-# otherwise the `#` will be interpreted as a comment.
+#
+# .. note::
+#     24-bit colors must be enclosed in single quotes to be parsed correctly,
+#     otherwise the `#` will be interpreted as a comment.
+#
 # Most modern terminals should support high color mode.
-# Example entry: `header = light red, default, default, #ff0000, default`
+#
+# Example entry (particular ugly):
+#
+# .. highlight:: ini
+#
+# ::
+#
+#  [palette]
+#  header = light red, default, default, '#ff0000', default
+#  edit = '', '', 'bold', '#FF00FF', '#12FF14'
+#  footer = '', '', '', '#121233', '#656599'
+#
 # See the default palettes in `khal/ui/colors.py` for all available keys.
-# If you can't theme an element in ikhal, please open an issue on github.
+# If you can't theme an element in ikhal, please open an issue on `github
+# <https://github.com/pimutils/khal/issues/new/choose>`_.
 [palette]

--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -215,6 +215,17 @@ def get_vdir_type(_: str) -> str:
     # TODO implement
     return 'calendar'
 
+def validate_palette_entry(attr, definition: str) -> bool:
+    if len(definition) not in (2, 3, 5):
+        logging.error('Invalid color definition for %s: %s, must be of length, 2, 3, or 5',
+                      attr, definition)
+        return False
+    if (definition[0] not in COLORS and definition[0] != '') or \
+            (definition[1] not in COLORS and definition[1] != ''):
+        logging.error('Invalid color definition for %s: %s, must be one of %s',
+                      attr, definition, COLORS.keys())
+        return False
+    return True
 
 def config_checks(
     config,
@@ -263,3 +274,11 @@ def config_checks(
         if config['calendars'][calendar]['color'] == 'auto':
             config['calendars'][calendar]['color'] = \
                 _get_color_from_vdir(config['calendars'][calendar]['path'])
+
+    # check palette settings
+    valid_palette = True
+    for attr in config.get('palette', []):
+        valid_palette = valid_palette and validate_palette_entry(attr, config['palette'][attr])
+    if not valid_palette:
+        logger.fatal('Invalid palette entry')
+        raise InvalidSettingsError()

--- a/khal/settings/utils.py
+++ b/khal/settings/utils.py
@@ -69,11 +69,10 @@ def is_timedelta(string: str) -> dt.timedelta:
         raise VdtValueError(f"Invalid timedelta: {string}")
 
 
-def weeknumber_option(option: str) -> Union[str, Literal[False]]:
+def weeknumber_option(option: str) -> Union[Literal['left', 'right'], Literal[False]]:
     """checks if *option* is a valid value
 
     :param option: the option the user set in the config file
-    :type option: str
     :returns: 'off', 'left', 'right' or False
     """
     option = option.lower()
@@ -89,11 +88,10 @@ def weeknumber_option(option: str) -> Union[str, Literal[False]]:
             "'off', 'left' or 'right'")
 
 
-def monthdisplay_option(option: str) -> str:
+def monthdisplay_option(option: str) -> Literal['firstday', 'firstfullweek']:
     """checks if *option* is a valid value
 
     :param option: the option the user set in the config file
-    :returns: firstday, firstfullweek
     """
     option = option.lower()
     if option == 'firstday':

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -772,13 +772,13 @@ class EventColumn(urwid.WidgetWrap):
             )
         else:
             self.editor = True
-            editor = CAttrMap(EventEditor(self.pane, event, update_colors, always_save=always_save), 'editor', 'editor focus')
+            editor = EventEditor(self.pane, event, update_colors, always_save=always_save)
 
             ContainerWidget = linebox[self.pane._conf['view']['frame']]
             new_pane = urwid.Columns([
-                ('weight', 2, ContainerWidget(editor)),
-                ('weight', 1, ContainerWidget(self.dlistbox))
-            ], dividechars=2, focus_column=0)
+                ('weight', 2, CAttrMap(ContainerWidget(editor), 'editor', 'editor focus')),
+                ('weight', 1, CAttrMap(ContainerWidget(self.dlistbox), 'reveal focus')),
+            ], dividechars=0, focus_column=0)
             new_pane.title = editor.title
 
             def teardown(data):

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1202,8 +1202,7 @@ class ClassicView(Pane):
         self.eventscolumn.original_widget.new(date, end)
 
 
-def _urwid_palette_entry(
-    name: str, color: str, hmethod: str) -> Tuple[str, str, str, str, str, str]:
+def _urwid_palette_entry(name: str, color: str, hmethod: str) -> Tuple[str, str, str, str, str, str]:
     """Create an urwid compatible palette entry.
 
     :param name: name of the new attribute in the palette

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -639,7 +639,7 @@ class EventColumn(urwid.WidgetWrap):
         self.divider = urwid.Divider('─')
         self.editor = False
         self._last_focused_date: Optional[dt.date] = None
-        self._eventshown = False
+        self._eventshown: Optional[Tuple[str, str]] = None
         self.event_width = int(self.pane._conf['view']['event_view_weighting'])
         self.delete_status = pane.delete_status
         self.toggle_delete_all = pane.toggle_delete_all
@@ -914,7 +914,7 @@ class EventColumn(urwid.WidgetWrap):
 
     def keypress(self, size: Tuple[int], key: Optional[str]) -> Optional[str]:
         prev_shown = self._eventshown
-        self._eventshown = False
+        self._eventshown = None
         self.clear_event_view()
 
         if key in self._conf['keybindings']['new']:
@@ -1026,6 +1026,7 @@ class SearchDialog(urwid.WidgetWrap):
             def keypress(self, size: Tuple[int], key: Optional[str]) -> Optional[str]:
                 if key == 'enter':
                     search_func(self.text)
+                    return None
                 else:
                     return super().keypress(size, key)
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1456,7 +1456,9 @@ def start_pane(
     loop.set_alarm_in(60, check_for_updates, pane)
 
     colors_ = 2**24 if color_mode == 'rgb' else 256
-    loop.screen.set_terminal_properties(colors=colors_, bright_is_bold=pane._conf['view']['bold_for_light_color'])
+    loop.screen.set_terminal_properties(
+        colors=colors_, bright_is_bold=pane._conf['view']['bold_for_light_color'],
+    )
 
     def ctrl_c(signum, f):
         raise urwid.ExitMainLoop()

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -35,7 +35,7 @@ from ..khalendar.exceptions import ReadOnlyCalendarError
 from . import colors
 from .base import Pane, Window
 from .editor import EventEditor, ExportDialog
-from .widgets import CalendarWidget, NColumns, NPile, button, linebox
+from .widgets import CalendarWidget, CAttrMap, NColumns, NPile, button, linebox
 from .widgets import ExtendedEdit as Edit
 
 logger = logging.getLogger('khal')
@@ -1076,8 +1076,8 @@ class ClassicView(Pane):
             toggle_delete_instance=self.toggle_delete_instance,
             dynamic_days=self._conf['view']['dynamic_days'],
         )
-        self.eventscolumn = ContainerWidget(EventColumn(pane=self, elistbox=elistbox))
-        calendar = CalendarWidget(
+        self.eventscolumn = ContainerWidget(CAttrMap(EventColumn(pane=self, elistbox=elistbox), 'eventcolumn', 'eventcolumn focus'))
+        calendar = CAttrMap(CalendarWidget(
             on_date_change=self.eventscolumn.original_widget.set_focus_date,
             keybindings=self._conf['keybindings'],
             on_press={key: self.new_event for key in self._conf['keybindings']['new']},
@@ -1085,7 +1085,7 @@ class ClassicView(Pane):
             weeknumbers=self._conf['locale']['weeknumbers'],
             monthdisplay=self._conf['view']['monthdisplay'],
             get_styles=collection.get_styles
-        )
+        ), 'calendar', 'calendar focus')
         if self._conf['view']['dynamic_days']:
             elistbox.set_focus_date_callback = calendar.set_focus_date
         else:

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -772,7 +772,7 @@ class EventColumn(urwid.WidgetWrap):
             )
         else:
             self.editor = True
-            editor = EventEditor(self.pane, event, update_colors, always_save=always_save)
+            editor = CAttrMap(EventEditor(self.pane, event, update_colors, always_save=always_save), 'editor', 'editor focus')
 
             ContainerWidget = linebox[self.pane._conf['view']['frame']]
             new_pane = urwid.Columns([

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1304,8 +1304,12 @@ def _add_calendar_colors(
     bg_color, fg_color = '', ''
     for attr in palette:
         if base and attr[0] == base:
-            bg_color = attr[5]
-            fg_color = attr[4]
+            if color_mode == 'rgb' and len(attr) >= 5:
+                bg_color = attr[5]
+                fg_color = attr[4]
+            else:
+                bg_color = attr[2]
+                fg_color = attr[1]
 
     for cal in collection.calendars:
         if cal['color'] == '':

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1342,8 +1342,19 @@ def start_pane(pane, callback, program_info='', quit_keys=None):
     logger.addHandler(header_handler)
 
     frame.open(pane, callback)
-    palette = _add_calendar_colors(
-        getattr(colors, pane._conf['view']['theme']), pane.collection)
+    palette = _add_calendar_colors(getattr(colors, pane._conf['view']['theme']), pane.collection)
+
+    def merge_palettes(pallete_a, pallete_b) -> List[Tuple[str, str, str, str, str]]:
+        """Merge two palettes together, with the second palette taking priority."""
+        merged = {}
+        for entry in pallete_a:
+            merged[entry[0]] = entry
+        for entry in pallete_b:
+            merged[entry[0]] = entry
+        return list(merged.values())
+
+    overwrite = [(key, *values) for key, values in pane._conf['palette'].items()]
+    palette = merge_palettes(palette, overwrite)
     loop = urwid.MainLoop(
         widget=frame,
         palette=palette,

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1387,9 +1387,9 @@ def start_pane(pane, callback, program_info='', quit_keys=None):
         loop.set_alarm_in(60, check_for_updates, pane)
 
     loop.set_alarm_in(60, check_for_updates, pane)
-    # Make urwid use 256 color mode.
+    # Make urwid use 2**24 color mode.
     loop.screen.set_terminal_properties(
-        colors=256, bright_is_bold=pane._conf['view']['bold_for_light_color'])
+        colors=2**24, bright_is_bold=pane._conf['view']['bold_for_light_color'])
 
     def ctrl_c(signum, f):
         raise urwid.ExitMainLoop()

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -644,7 +644,7 @@ class EventColumn(urwid.WidgetWrap):
         self.delete_status = pane.delete_status
         self.toggle_delete_all = pane.toggle_delete_all
         self.toggle_delete_instance = pane.toggle_delete_instance
-        self.dlistbox: DateListBox = elistbox
+        self.dlistbox: DListBox = elistbox
         self.container = urwid.Pile([self.dlistbox])
         urwid.WidgetWrap.__init__(self, self.container)
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -24,7 +24,7 @@ import logging
 import signal
 import sys
 from enum import IntEnum
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Literal, Optional, Tuple
 
 import click
 import urwid
@@ -1202,11 +1202,20 @@ class ClassicView(Pane):
         self.eventscolumn.original_widget.new(date, end)
 
 
-def _urwid_palette_entry(name: str, color: str, hmethod: str) -> Tuple[str, str, str, str, str, str]:
+def _urwid_palette_entry(
+    name: str, color: str, hmethod: str, color_mode: Literal['256color', 'rgb'],
+    foreground: str = '', background: str = '',
+) -> Tuple[str, str, str, str, str, str]:
     """Create an urwid compatible palette entry.
 
     :param name: name of the new attribute in the palette
     :param color: color for the new attribute
+    :param hmethod: which highlighting mode to use, foreground or background
+    :param color_mode: which color mode we are in, if we are in 256-color mode,
+    we transform 24-bit/RGB colors to a (somewhat) matching 256-color set color
+    :param foreground: the foreground color to apply if we use background highlighting method
+    :param background: the background color to apply if we use foreground highlighting method
+
     :returns: an urwid palette entry
     """
     from ..terminal import COLORS
@@ -1217,9 +1226,8 @@ def _urwid_palette_entry(name: str, color: str, hmethod: str) -> Tuple[str, str,
         # Colors from the 256 color palette need to be prefixed with h in
         # urwid.
         color = 'h' + color
-    else:
-        # 24-bit colors are not supported by urwid.
-        # Convert it to some color on the 256 color palette that might resemble
+    elif color_mode == '256color':
+        # Convert to some color on the 256 color palette that might resemble
         # the 24-bit color.
         # First, generate the palette (indices 16-255 only). This assumes, that
         # the terminal actually uses the same palette, which may or may not be
@@ -1262,9 +1270,9 @@ def _urwid_palette_entry(name: str, color: str, hmethod: str) -> Tuple[str, str,
     # We unconditionally add the color to the high color slot. It seems to work
     # in lower color terminals as well.
     if hmethod in ['fg', 'foreground']:
-        return (name, '', '', '', color, '')
+        return (name, '', '', '', color, background)
     else:
-        return (name, '', '', '', '', color)
+        return (name, '', '', '', foreground, color)
 
 
 def _add_calendar_colors(palette: List, collection: CalendarCollection) -> List:

--- a/khal/ui/colors.py
+++ b/khal/ui/colors.py
@@ -52,6 +52,11 @@ dark = [
     ('frame focus color', 'dark blue', 'black'),
     ('frame focus top', 'dark magenta', 'black'),
 
+    ('eventcolumn', '', '', ''),
+    ('eventcolumn focus', '', '', ''),
+    ('calendar', '', '', ''),
+    ('calendar focus', '', '', ''),
+
     ('editbx', 'light gray', 'dark blue'),
     ('editcp', 'black', 'light gray', 'standout'),
     ('popupbg', 'white', 'black', 'bold'),
@@ -89,6 +94,11 @@ light = [
     ('frame focus', 'light red', 'white'),
     ('frame focus color', 'dark blue', 'white'),
     ('frame focus top', 'dark magenta', 'white'),
+
+    ('eventcolumn', '', '', ''),
+    ('eventcolumn focus', '', '', ''),
+    ('calendar', '', '', ''),
+    ('calendar focus', '', '', ''),
 
     ('editbx', 'light gray', 'dark blue'),
     ('editcp', 'black', 'light gray', 'standout'),

--- a/khal/ui/colors.py
+++ b/khal/ui/colors.py
@@ -19,13 +19,14 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+from typing import Dict, List, Tuple
 
 dark = [
     ('header', 'white', 'black'),
     ('footer', 'white', 'black'),
     ('line header', 'black', 'white', 'bold'),
     ('alt header', 'white', '', 'bold'),
-    ('bright', 'dark blue', 'white', ('bold', 'standout')),
+    ('bright', 'dark blue', 'white', 'bold,standout'),
     ('list', 'black', 'white'),
     ('list focused', 'white', 'light blue', 'bold'),
     ('edit', 'black', 'white'),
@@ -67,7 +68,7 @@ light = [
     ('footer', 'black', 'white'),
     ('line header', 'black', 'white', 'bold'),
     ('alt header', 'black', '', 'bold'),
-    ('bright', 'dark blue', 'white', ('bold', 'standout')),
+    ('bright', 'dark blue', 'white', 'bold,standout'),
     ('list', 'black', 'white'),
     ('list focused', 'white', 'light blue', 'bold'),
     ('edit', 'black', 'white'),
@@ -80,7 +81,7 @@ light = [
     ('today', 'black', 'light gray'),
 
     ('date header', '', 'white'),
-    ('date header focused', 'white', 'dark gray', ('bold', 'standout')),
+    ('date header focused', 'white', 'dark gray', 'bold,standout'),
     ('date header selected', 'dark gray', 'light cyan'),
 
     ('dayname', 'dark gray', 'white'),
@@ -104,3 +105,5 @@ light = [
     ('popupper', 'black', 'light gray'),
     ('caption', 'black', '', ''),
 ]
+
+themes: Dict[str, List[Tuple[str, ...]]] = {'light': light, 'dark': dark}

--- a/khal/ui/colors.py
+++ b/khal/ui/colors.py
@@ -29,7 +29,7 @@ dark = [
     ('list', 'black', 'white'),
     ('list focused', 'white', 'light blue', 'bold'),
     ('edit', 'black', 'white'),
-    ('edit focused', 'white', 'light blue', 'bold'),
+    ('edit focus', 'white', 'light blue', 'bold'),
     ('button', 'black', 'dark cyan'),
     ('button focused', 'white', 'light blue', 'bold'),
 
@@ -44,7 +44,6 @@ dark = [
     ('dayname', 'light gray', ''),
     ('monthname', 'light gray', ''),
     ('weeknumber_right', 'light gray', ''),
-    ('edit', 'white', 'dark blue'),
     ('alert', 'white', 'dark red'),
     ('mark', 'white', 'dark green'),
     ('frame', 'white', 'black'),
@@ -72,7 +71,7 @@ light = [
     ('list', 'black', 'white'),
     ('list focused', 'white', 'light blue', 'bold'),
     ('edit', 'black', 'white'),
-    ('edit focused', 'white', 'light blue', 'bold'),
+    ('edit focus', 'white', 'light blue', 'bold'),
     ('button', 'black', 'dark cyan'),
     ('button focused', 'white', 'light blue', 'bold'),
 
@@ -87,7 +86,6 @@ light = [
     ('dayname', 'dark gray', 'white'),
     ('monthname', 'dark gray', 'white'),
     ('weeknumber_right', 'dark gray', 'white'),
-    ('edit', 'white', 'dark blue'),
     ('alert', 'white', 'dark red'),
     ('mark', 'white', 'dark green'),
     ('frame', 'dark gray', 'white'),

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -369,7 +369,7 @@ class EventEditor(urwid.WidgetWrap):
             self.event.recurobject, self._conf, event.start_local,
         )
         self.summary = urwid.AttrMap(ExtendedEdit(
-            caption=('caption', 'Title:       '), edit_text=event.summary), 'edit'
+            caption=('caption', 'Title:       '), edit_text=event.summary), 'edit', 'edit focus',
         )
 
         divider = urwid.Divider(' ')
@@ -388,13 +388,13 @@ class EventEditor(urwid.WidgetWrap):
                 edit_text=self.description,
                 multiline=True
             ),
-            'edit'
+            'edit', 'edit focus',
         )
         self.location = urwid.AttrMap(ExtendedEdit(
-            caption=('caption', 'Location:    '), edit_text=self.location), 'edit'
+            caption=('caption', 'Location:    '), edit_text=self.location), 'edit', 'edit focus',
         )
         self.categories = urwid.AttrMap(ExtendedEdit(
-            caption=('caption', 'Categories:  '), edit_text=self.categories), 'edit'
+            caption=('caption', 'Categories:  '), edit_text=self.categories), 'edit', 'edit focus',
         )
         self.attendees = urwid.AttrMap(
             ExtendedEdit(
@@ -402,10 +402,10 @@ class EventEditor(urwid.WidgetWrap):
                 edit_text=self.attendees,
                 multiline=True
             ),
-            'edit'
+            'edit', 'edit focus',
         )
         self.url = urwid.AttrMap(ExtendedEdit(
-            caption=('caption', 'URL:         '), edit_text=self.url), 'edit'
+            caption=('caption', 'URL:         '), edit_text=self.url), 'edit', 'edit focus',
         )
         self.alarms = AlarmsEditor(self.event)
         self.pile = NListBox(urwid.SimpleFocusListWalker([

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -43,6 +43,7 @@ from .widgets import (
     button,
 )
 
+from typing import Dict, List, Tuple
 
 class StartEnd:
 
@@ -88,7 +89,8 @@ class CalendarPopUp(urwid.PopUpLauncher):
                 weeknumbers=self._weeknumbers,
                 monthdisplay=self._monthdisplay,
                 initial=initial_date)
-            pop_up = urwid.LineBox(pop_up)
+            pop_up = CAttrMap(pop_up, 'calendar', ' calendar focus')
+            pop_up = CAttrMap(urwid.LineBox(pop_up), 'calendar', 'calendar focus')
             return pop_up
 
     def get_pop_up_parameters(self):
@@ -125,7 +127,7 @@ class DateEdit(urwid.WidgetWrap):
             on_date_change=on_date_change)
         wrapped = CalendarPopUp(self._edit, on_date_change, weeknumbers,
                                 firstweekday, monthdisplay, keybindings)
-        padded = urwid.Padding(wrapped, align='left', width=datewidth, left=0, right=1)
+        padded = CAttrMap(urwid.Padding(wrapped, align='left', width=datewidth, left=0, right=1), 'calendar', 'calendar focus')
         super().__init__(padded)
 
     def _validate(self, text):

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -20,7 +20,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import datetime as dt
-from typing import Callable, Dict, List, Literal, Optional
+from typing import Callable, Dict, List, Literal, Optional, Tuple
 
 import urwid
 
@@ -43,7 +43,6 @@ from .widgets import (
     button,
 )
 
-from typing import Dict, List, Tuple
 
 class StartEnd:
 
@@ -56,7 +55,7 @@ class StartEnd:
 
 
 class CalendarPopUp(urwid.PopUpLauncher):
-    def __init__(self, widget, on_date_change, weeknumbers=False,
+    def __init__(self, widget, on_date_change, weeknumbers: Literal['left', 'right', False]=False,
                  firstweekday=0, monthdisplay='firstday', keybindings=None) -> None:
         self._on_date_change = on_date_change
         self._weeknumbers = weeknumbers
@@ -127,10 +126,13 @@ class DateEdit(urwid.WidgetWrap):
             on_date_change=on_date_change)
         wrapped = CalendarPopUp(self._edit, on_date_change, weeknumbers,
                                 firstweekday, monthdisplay, keybindings)
-        padded = CAttrMap(urwid.Padding(wrapped, align='left', width=datewidth, left=0, right=1), 'calendar', 'calendar focus')
+        padded = CAttrMap(
+            urwid.Padding(wrapped, align='left', width=datewidth, left=0, right=1),
+            'calendar', 'calendar focus',
+        )
         super().__init__(padded)
 
-    def _validate(self, text):
+    def _validate(self, text: str):
         try:
             _date = dt.datetime.strptime(text, self._dateformat).date()
         except ValueError:
@@ -376,8 +378,9 @@ class EventEditor(urwid.WidgetWrap):
 
         divider = urwid.Divider(' ')
 
-        def decorate_choice(c):
-            return ('calendar ' + c['name'], c['name'])
+        def decorate_choice(c) -> Tuple[str, str]:
+            return ('calendar ' + c['name'] + ' popup', c['name'])
+
         self.calendar_chooser= CAttrMap(Choice(
             [self.collection._calendars[c] for c in self.collection.writable_names],
             self.collection._calendars[self.event.calendar],

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -20,7 +20,7 @@
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 import datetime as dt
-from typing import Callable, Dict, List, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Literal, Optional, Tuple
 
 import urwid
 
@@ -43,6 +43,8 @@ from .widgets import (
     button,
 )
 
+if TYPE_CHECKING:
+    import khal.khalendar.event
 
 class StartEnd:
 
@@ -177,8 +179,10 @@ class StartEndEditor(urwid.WidgetWrap):
         """
         self.allday = not isinstance(start, dt.datetime)
         self.conf = conf
-        self._startdt, self._original_start = start, start
-        self._enddt, self._original_end = end, end
+        self._startdt: dt.date = start
+        self._original_start: dt.date = start
+        self._enddt: dt.date = end
+        self._original_end: dt.date = end
         self.on_start_date_change = on_start_date_change
         self.on_end_date_change = on_end_date_change
         self._datewidth = len(start.strftime(self.conf['locale']['longdateformat']))
@@ -275,6 +279,8 @@ class StartEndEditor(urwid.WidgetWrap):
             self._startdt = dt.datetime.combine(self._startdt, dt.datetime.min.time())
             self._enddt = dt.datetime.combine(self._enddt, dt.datetime.min.time())
         elif self.allday is False and state is True:
+            assert isinstance(self._startdt, dt.datetime)
+            assert isinstance(self._enddt, dt.datetime)
             self._startdt = self._startdt.date()
             self._enddt = self._enddt.date()
         self.allday = state
@@ -340,7 +346,13 @@ class StartEndEditor(urwid.WidgetWrap):
 class EventEditor(urwid.WidgetWrap):
     """Widget that allows Editing one `Event()`"""
 
-    def __init__(self, pane, event: 'khal.event.Event', save_callback=None, always_save: bool=False) -> None:
+    def __init__(
+        self,
+        pane,
+        event: 'khal.khalendar.event.Event',
+        save_callback=None,
+        always_save: bool=False,
+    ) -> None:
         """
         :param save_callback: call when saving event with new start and end
              dates and recursiveness of original and edited event as parameters
@@ -562,12 +574,12 @@ class EventEditor(urwid.WidgetWrap):
             self.pane.window.alert(
                 ('light red', 'Unsaved changes! Hit ESC again to discard.'))
             self._abort_confirmed = True
-            return
+            return None
         else:
             self._abort_confirmed = False
         if key in self.pane._conf['keybindings']['save']:
             self.save(None)
-            return
+            return None
         return super().keypress(size, key)
 
 

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -161,14 +161,15 @@ class DateEdit(urwid.WidgetWrap):
 class StartEndEditor(urwid.WidgetWrap):
     """Widget for editing start and end times (of an event)."""
 
-    def __init__(self, start, end, conf,
+    def __init__(self,
+                 start: dt.datetime,
+                 end: dt.datetime,
+                 conf,
                  on_start_date_change=lambda x: None,
                  on_end_date_change=lambda x: None,
 
                  ) -> None:
         """
-        :type start: datetime.datetime
-        :type end: datetime.datetime
         :param on_start_date_change: a callable that gets called everytime a new
             start date is entered, with that new date as an argument
         :param on_end_date_change: same as for on_start_date_change, just for the
@@ -260,7 +261,7 @@ class StartEndEditor(urwid.WidgetWrap):
         self._enddt = self.localize_end(dt.datetime.combine(date, self._end_time))
         self.on_end_date_change(date)
 
-    def toggle(self, checkbox, state):
+    def toggle(self, checkbox, state: bool):
         """change from allday to datetime event
 
         :param checkbox: the checkbox instance that is used for toggling, gets
@@ -268,7 +269,6 @@ class StartEndEditor(urwid.WidgetWrap):
         :type checkbox: checkbox
         :param state: state the event will toggle to;
                       True if allday event, False if datetime
-        :type state: bool
         """
 
         if self.allday is True and state is False:
@@ -340,14 +340,12 @@ class StartEndEditor(urwid.WidgetWrap):
 class EventEditor(urwid.WidgetWrap):
     """Widget that allows Editing one `Event()`"""
 
-    def __init__(self, pane, event, save_callback=None, always_save=False) -> None:
+    def __init__(self, pane, event: 'khal.event.Event', save_callback=None, always_save: bool=False) -> None:
         """
-        :type event: khal.event.Event
         :param save_callback: call when saving event with new start and end
              dates and recursiveness of original and edited event as parameters
         :type save_callback: callable
         :param always_save: save event even if it has not changed
-        :type always_save: bool
         """
         self.pane = pane
         self.event = event
@@ -559,7 +557,7 @@ class EventEditor(urwid.WidgetWrap):
         self._abort_confirmed = False
         self.pane.window.backtrack()
 
-    def keypress(self, size, key):
+    def keypress(self, size: Tuple[int], key: str) -> Optional[str]:
         if key in ['esc'] and self.changed and not self._abort_confirmed:
             self.pane.window.alert(
                 ('light red', 'Unsaved changes! Hit ESC again to discard.'))

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -808,8 +808,8 @@ class ExportDialog(urwid.WidgetWrap):
             caption='Location: ', edit_text="~/%s.ics" % event.summary.strip())
         lines.append(export_location)
         lines.append(urwid.Divider(' '))
-        lines.append(
-            urwid.Button('Save', on_press=this_func, user_data=export_location)
-        )
+        lines.append(CAttrMap(
+            urwid.Button('Save', on_press=this_func, user_data=export_location),
+            'button', 'button focus'))
         content = NPile(lines)
         urwid.WidgetWrap.__init__(self, urwid.LineBox(content))

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -712,14 +712,9 @@ def button(*args,
 
 
 class CAttrMap(urwid.AttrMap):
-    """A variant of AttrMap that exposes the some properties of the original widget"""
-    @property
-    def active(self):
-        return self.original_widget.active
-
-    @property
-    def changed(self):
-        return self.original_widget.changed
+    """A variant of AttrMap that exposes all properties of the original widget"""
+    def __getattr__(self, name):
+        return getattr(self.original_widget, name)
 
 
 class CPadding(urwid.Padding):

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -26,7 +26,7 @@ if they are large, into their own files
 """
 import datetime as dt
 import re
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 import urwid
 
@@ -77,7 +77,7 @@ def goto_end_of_line(text):
 class ExtendedEdit(urwid.Edit):
     """A text editing widget supporting some more editing commands"""
 
-    def keypress(self, size, key: str) -> Optional[Tuple[Tuple[int, int], str]]:
+    def keypress(self, size: Tuple[int], key: Optional[str]) -> Optional[str]:
         if key == 'ctrl w':
             self._delete_word()
         elif key == 'ctrl u':
@@ -201,7 +201,8 @@ class TimeWidget(DateTimeWidget):
 
 class Choice(urwid.PopUpLauncher):
     def __init__(
-            self, choices, active, decorate_func=None, overlay_width=32, callback=lambda: None,
+        self, choices: List[str], active: str,
+        decorate_func=None, overlay_width: int=32, callback=lambda: None,
     ) -> None:
         self.choices = choices
         self._callback = callback
@@ -211,9 +212,7 @@ class Choice(urwid.PopUpLauncher):
 
     def create_pop_up(self):
         pop_up = ChoiceList(self, callback=self._callback)
-        urwid.connect_signal(
-            pop_up, 'close', lambda button: self.close_pop_up(),
-        )
+        urwid.connect_signal(pop_up, 'close', lambda button: self.close_pop_up())
         return pop_up
 
     def get_pop_up_parameters(self):
@@ -235,8 +234,7 @@ class Choice(urwid.PopUpLauncher):
         self._active = val
         self.button = urwid.Button(self._decorate(self._active))
         urwid.PopUpLauncher.__init__(self, self.button)
-        urwid.connect_signal(self.button, 'click',
-                             lambda button: self.open_pop_up())
+        urwid.connect_signal(self.button, 'click', lambda button: self.open_pop_up())
 
 
 class ChoiceList(urwid.WidgetWrap):

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -252,6 +252,7 @@ class ChoiceList(urwid.WidgetWrap):
                 button(
                     parent._decorate(c),
                     attr_map='popupbg',
+                    focus_map='popupbg focus',
                     on_press=self.set_choice,
                     user_data=c,
                 )
@@ -533,7 +534,7 @@ class AlarmsEditor(urwid.WidgetWrap):
                 (21, self.duration),
                 (14, urwid.Padding(self.direction, right=1)),
                 self.description,
-                (10, urwid.Button('Delete', on_press=delete_handler, user_data=self)),
+                (10, button('Delete', on_press=delete_handler, user_data=self)),
             ])
 
             urwid.WidgetWrap.__init__(self, self.columns)
@@ -552,7 +553,7 @@ class AlarmsEditor(urwid.WidgetWrap):
         self.pile = NPile(
             [urwid.Text('Alarms:')] +
             [self.AlarmEditor(a, self.remove_alarm) for a in event.alarms] +
-            [urwid.Columns([(12, urwid.Button('Add', on_press=self.add_alarm))])])
+            [urwid.Columns([(12, button('Add', on_press=self.add_alarm))])])
 
         urwid.WidgetWrap.__init__(self, self.pile)
 
@@ -701,7 +702,7 @@ linebox = {
 }
 
 def button(*args,
-           attr_map: str='button', focus_map='button focused',
+           attr_map: str='button', focus_map='button focus',
            padding_left=0, padding_right=0,
            **kwargs):
     """wrapping an urwid button in attrmap and padding"""

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -582,29 +582,31 @@ class AlarmsEditor(urwid.WidgetWrap):
 
 class FocusLineBoxWidth(urwid.WidgetDecoration, urwid.WidgetWrap):
     def __init__(self, widget) -> None:
-        hline = urwid.Divider('─')
-        hline_focus = urwid.Divider('━')
-        self._vline = urwid.SolidFill('│')
-        self._vline_focus = urwid.SolidFill('┃')
+        # we cheat here with the attrs, if we use thick dividers we apply the
+        # focus attr group. We probably should fix this in render()
+        hline = urwid.AttrMap(urwid.Divider('─'), 'frame')
+        hline_focus = urwid.AttrMap(urwid.Divider('━'), 'frame focus')
+        self._vline = urwid.AttrMap(urwid.SolidFill('│'), 'frame')
+        self._vline_focus = urwid.AttrMap(urwid.SolidFill('┃'), 'frame focus')
         self._topline = urwid.Columns([
-            ('fixed', 1, urwid.Text('┌')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┌'), 'frame')),
             hline,
-            ('fixed', 1, urwid.Text('┐')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┐'), 'frame')),
         ])
         self._topline_focus = urwid.Columns([
-            ('fixed', 1, urwid.Text('┏')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┏'), 'frame focus')),
             hline_focus,
-            ('fixed', 1, urwid.Text('┓')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┓'), 'frame focus')),
         ])
         self._bottomline = urwid.Columns([
-            ('fixed', 1, urwid.Text('└')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('└'), 'frame')),
             hline,
-            ('fixed', 1, urwid.Text('┘')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┘'), 'frame')),
         ])
         self._bottomline_focus = urwid.Columns([
-            ('fixed', 1, urwid.Text('┗')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┗'), 'frame focus')),
             hline_focus,
-            ('fixed', 1, urwid.Text('┛')),
+            ('fixed', 1, urwid.AttrMap(urwid.Text('┛'), 'frame focus')),
         ])
         self._middle = urwid.Columns(
             [('fixed', 1, self._vline), widget, ('fixed', 1, self._vline)],


### PR DESCRIPTION
This PR allows to override ikhal's color theme with a custom palette. This is useful to style certain elements of ikhal individually.

Palette entries take the form of `key = foreground, background, mono, foreground_high, background_high` where foreground and background are used in "low color mode"  and foreground_high and background_high are used in "high
 color mode" and mono if only monocolor is supported. If you don't want to set a value for a certain color, use an empty string (`''`). Valid entries for low color mode are listed on the [urwid website](http://urwid.org/manual/displayattributes.html#standard-foreground-colors). For high color mode you can use any valid 24-bit color value, e.g. `'#ff0000'` (Note: 24-bit color values must be enclosed in quotes).

Most modern terminals should support high color mode. 

Example entry: `header = light red, default, default, '#ff0000', '#ff0011'`
See the default palettes in `khal/ui/colors.py` for all available keys. If you can't theme an element in ikhal, please open an issue on github.

Example config:
<img width="515" alt="image" src="https://github.com/pimutils/khal/assets/275330/0eb2f3a7-90bb-42c5-a464-8355b2d659c0">

leads to this ugliness:
<img width="682" alt="image" src="https://github.com/pimutils/khal/assets/275330/b3f2bb03-4b6d-4283-9987-24764c8f1b75">

fixes #1219