### PR TITLE
Add .python-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ doc/source/configspec.rst
 env/
 venv/
 .hypothesis/
+.python-version


### PR DESCRIPTION
.python-version is used by pyenv to specify the used python-version by directory. So this is very usefull for testing.