### PR TITLE
poc: format event html descriptions

### DIFF
--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -39,7 +39,7 @@ from ..exceptions import FatalError
 from ..icalendar import cal_from_ics, delete_instance, invalid_timezone
 from ..parse_datetime import timedelta2str
 from ..terminal import get_color
-from ..utils import generate_random_uid, format_text, is_aware, to_naive_utc, to_unix_time
+from ..utils import format_text, generate_random_uid, is_aware, to_naive_utc, to_unix_time
 
 logger = logging.getLogger('khal')
 

--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -39,7 +39,7 @@ from ..exceptions import FatalError
 from ..icalendar import cal_from_ics, delete_instance, invalid_timezone
 from ..parse_datetime import timedelta2str
 from ..terminal import get_color
-from ..utils import generate_random_uid, is_aware, to_naive_utc, to_unix_time
+from ..utils import generate_random_uid, format_text, is_aware, to_naive_utc, to_unix_time
 
 logger = logging.getLogger('khal')
 
@@ -684,7 +684,10 @@ class Event:
         attributes["alarm-symbol"] = self._alarm_str
         attributes["title"] = self.summary
         attributes["organizer"] = self.organizer.strip()
-        attributes["description"] = self.description.strip()
+        if bool(os.getenv("HTML_FORMATTED")):
+            attributes["description"] = format_text(self.description.strip())
+        else:
+            attributes["description"] = self.description.strip()
         attributes["description-separator"] = ""
         if attributes["description"]:
             attributes["description-separator"] = " :: "

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -32,6 +32,8 @@ from typing import Iterator, List, Optional, Tuple
 
 import pytz
 
+from markdownify import markdownify as md
+
 
 def generate_random_uid() -> str:
     """generate a random uid
@@ -76,6 +78,17 @@ def find_unmatched_sgr(string: str) -> Optional[str]:
         return sgr
     else:
         return None
+
+
+def format_text(raw_data: str) -> str:
+    md_opts = {
+        "convert": ["br", "li", "a"],
+        "escape_asterisks": False,
+        "escape_underscores": False,
+        "wrap": True,
+    }
+    html_data = "\n".join(("<html>", raw_data, "</html>"))
+    return md(html_data, **md_opts)
 
 
 def color_wrap(text: str, width: int = 70) -> List[str]:

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -31,7 +31,6 @@ from textwrap import wrap
 from typing import Iterator, List, Optional, Tuple
 
 import pytz
-
 from markdownify import markdownify as md
 
 


### PR DESCRIPTION
HTML event descriptions are difficult to read, especially when originating from marketing or tech firms.

This PoC proposes transforming event description text through a filter that strips the tag soup and formats text for easier reading on a console displays.

An alternative to my PR would be for users to configure their own formatters, and have subprocess pipe the event descriptions into the process. For example, the user could configure `~/.config/khal/config` like so:

```
[view]
event_description_formatter = pandoc -f html -t plain
```

To my knowledge there's no way of knowing if an event description is going to be html, so another feature goal could be to have some kind of heuristics and only format if a number of html tags are detected.

This PoC is something I hacked together in an afternoon; as per your [suggestion](https://khal.readthedocs.io/en/latest/hacking.html#hacking), I didn't want to burn too much time on it in case you reject the feature proposal. Thank you for all the work on khal, I'd love to contribute back as its worked wonders for my smooth ADHD brain.