### PR TITLE
Remove mime association from khal.desktop

### DIFF
--- a/misc/khal.desktop
+++ b/misc/khal.desktop
@@ -6,5 +6,3 @@ Comment=Terminal CLI calendar application
 Exec=ikhal
 Terminal=true
 Type=Application
-
-MimeType=text/calendar


### PR DESCRIPTION
 ikhal cannot open calendar files natively and just errors out
 
 Originally reported at https://bugs.archlinux.org/task/79538