### PR TITLE
[ikhal] add option to disable mouse, fixes #1289

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ env/
 venv/
 .hypothesis/
 .python-version
+.dmypy.json

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -52,3 +52,4 @@ Jason Cox - me [at] jasoncarloscox [dot] com - https://jasoncarloscox.com
 Michael Tretter - michael.tretter [at] posteo [dot] net
 Raúl Medina - raulmgcontact [at] gmail (dot] com
 Matthew Rademaker - matthew.rademaker [at] gmail [dot] com
+Valentin Iovene - val [at] too [dot] gy

--- a/khal.conf.sample
+++ b/khal.conf.sample
@@ -30,3 +30,4 @@ monthdisplay = firstday
 default_calendar = home
 timedelta = 2d # the default timedelta that list uses
 highlight_event_days = True  # the default is False
+enable_mouse = True  # mouse is enabled by default in interactive mode

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -97,7 +97,7 @@ def mouse_option(f):
     o = click.option(
         '--mouse/--no-mouse',
         is_flag=True,
-        default=True,
+        default=None,
         help='Disable mouse in interactive UI'
     )
     return o(f)
@@ -494,7 +494,8 @@ def _get_cli():
     @click.pass_context
     def interactive(ctx, include_calendar, exclude_calendar, mouse):
         '''Interactive UI. Also launchable via `ikhal`.'''
-        ctx.obj['conf']['default']['enable_mouse'] = mouse
+        if mouse is not None:
+            ctx.obj['conf']['default']['enable_mouse'] = mouse
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],
@@ -511,7 +512,8 @@ def _get_cli():
     def interactive_cli(ctx, config, include_calendar, exclude_calendar, mouse):
         '''Interactive UI. Also launchable via `khal interactive`.'''
         prepare_context(ctx, config)
-        ctx.obj['conf']['default']['enable_mouse'] = mouse
+        if mouse is not None:
+            ctx.obj['conf']['default']['enable_mouse'] = mouse
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -94,7 +94,7 @@ def multi_calendar_option(f):
 
 
 def no_mouse_option(f):
-    o = click.option('--no-mouse', is_flag=True,
+    o = click.option('--mouse/--no-mouse', is_flag=True, default=True
                      help='Disable mouse in interactive UI')
     return o(f)
 

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -93,9 +93,13 @@ def multi_calendar_option(f):
     return d(a(f))
 
 
-def no_mouse_option(f):
-    o = click.option('--mouse/--no-mouse', is_flag=True, default=True
-                     help='Disable mouse in interactive UI')
+def mouse_option(f):
+    o = click.option(
+        '--mouse/--no-mouse',
+        is_flag=True,
+        default=True,
+        help='Disable mouse in interactive UI'
+    )
     return o(f)
 
 
@@ -486,12 +490,11 @@ def _get_cli():
 
     @cli.command()
     @multi_calendar_option
-    @no_mouse_option
+    @mouse_option
     @click.pass_context
-    def interactive(ctx, include_calendar, exclude_calendar, no_mouse):
+    def interactive(ctx, include_calendar, exclude_calendar, mouse):
         '''Interactive UI. Also launchable via `ikhal`.'''
-        if no_mouse:
-            ctx.obj['conf']['default']['enable_mouse'] = False
+        ctx.obj['conf']['default']['enable_mouse'] = mouse
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],
@@ -503,13 +506,12 @@ def _get_cli():
     @click.command()
     @global_options
     @multi_calendar_option
-    @no_mouse_option
+    @mouse_option
     @click.pass_context
-    def interactive_cli(ctx, config, include_calendar, exclude_calendar, no_mouse):
+    def interactive_cli(ctx, config, include_calendar, exclude_calendar, mouse):
         '''Interactive UI. Also launchable via `khal interactive`.'''
         prepare_context(ctx, config)
-        if no_mouse:
-            ctx.obj['conf']['default']['enable_mouse'] = False
+        ctx.obj['conf']['default']['enable_mouse'] = mouse
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],

--- a/khal/cli.py
+++ b/khal/cli.py
@@ -93,6 +93,12 @@ def multi_calendar_option(f):
     return d(a(f))
 
 
+def no_mouse_option(f):
+    o = click.option('--no-mouse', is_flag=True,
+                     help='Disable mouse in interactive UI')
+    return o(f)
+
+
 def _select_one_calendar_callback(ctx, option, calendar):
     if isinstance(calendar, tuple):
         if len(calendar) > 1:
@@ -480,9 +486,12 @@ def _get_cli():
 
     @cli.command()
     @multi_calendar_option
+    @no_mouse_option
     @click.pass_context
-    def interactive(ctx, include_calendar, exclude_calendar):
+    def interactive(ctx, include_calendar, exclude_calendar, no_mouse):
         '''Interactive UI. Also launchable via `ikhal`.'''
+        if no_mouse:
+            ctx.obj['conf']['default']['enable_mouse'] = False
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],
@@ -494,10 +503,13 @@ def _get_cli():
     @click.command()
     @global_options
     @multi_calendar_option
+    @no_mouse_option
     @click.pass_context
-    def interactive_cli(ctx, config, include_calendar, exclude_calendar):
+    def interactive_cli(ctx, config, include_calendar, exclude_calendar, no_mouse):
         '''Interactive UI. Also launchable via `khal interactive`.'''
         prepare_context(ctx, config)
+        if no_mouse:
+            ctx.obj['conf']['default']['enable_mouse'] = False
         controllers.interactive(
             build_collection(
                 ctx.obj['conf'],

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -216,6 +216,10 @@ default_event_duration = timedelta(default='1d')
 # Define the default duration for an event ('khal new' only)
 default_dayevent_duration = timedelta(default='1h')
 
+# Whether the mouse should be enabled in interactive mode ('khal interactive' and
+# 'ikhal' only)
+enable_mouse = boolean(default=True)
+
 
 # The view section contains configuration options that effect the visual appearance
 # when using khal and ikhal.

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1344,7 +1344,12 @@ def start_pane(pane, callback, program_info='', quit_keys=None):
     palette = _add_calendar_colors(
         getattr(colors, pane._conf['view']['theme']), pane.collection)
     loop = urwid.MainLoop(
-        frame, palette, unhandled_input=frame.on_key_press, pop_ups=True)
+        widget=frame,
+        palette=palette,
+        unhandled_input=frame.on_key_press,
+        pop_ups=True,
+        handle_mouse=pane._conf['default']['enable_mouse'],
+    )
     frame.loop = loop
 
     def redraw_today(loop, pane, meta=None):

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -55,6 +55,7 @@ class TestSettings:
                 'default_event_duration': dt.timedelta(days=1),
                 'default_dayevent_duration': dt.timedelta(hours=1),
                 'show_all_days': False,
+                'enable_mouse': True,
             }
         }
         for key in comp_config:
@@ -102,8 +103,8 @@ class TestSettings:
                 'timedelta': dt.timedelta(days=2),
                 'default_event_duration': dt.timedelta(days=1),
                 'default_dayevent_duration': dt.timedelta(hours=1),
-
-                'show_all_days': False
+                'show_all_days': False,
+                'enable_mouse': True,
             }
         }
         for key in comp_config:


### PR DESCRIPTION
This is done by passing the `handle_mouse` Boolean argument to urwid's main loop (currently unused). By default, the mouse remains enabled (see `khal.spec`). Mouse can be disabled either by setting `enable_mouse = False` in the `[default]` section of khal's config file, or by passing the `--no-mouse` flag to the `khal interactive` or `ikhal` click commands.

fixes #1289