### PR TITLE
support for color theme plugins

### DIFF
--- a/khal/api.py
+++ b/khal/api.py
@@ -1,0 +1,1 @@
+from .ui.colors import register_color_theme  # noqa

--- a/khal/api.py
+++ b/khal/api.py
@@ -1,1 +1,3 @@
-from .ui.colors import register_color_theme  # noqa
+from .ui.colors import register_color_theme
+
+__all__ = ["register_color_theme"]

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -258,7 +258,7 @@ blank_line_before_day = boolean(default=False)
 #
 # __ http://urwid.org/manual/displayattributes.html
 # .. _github: https://github.com/pimutils/khal/issues
-theme = option('dark', 'light', default='dark')
+theme = string(default='dark')
 
 # Whether to show a visible frame (with *box drawing* characters) around some
 # (groups of) elements or not. There are currently several different frame

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -31,7 +31,7 @@ import urwid
 
 from .. import utils
 from ..khalendar import CalendarCollection
-from ..khalendar.exceptions import ReadOnlyCalendarError
+from ..khalendar.exceptions import FatalError, ReadOnlyCalendarError
 from . import colors
 from .base import Pane, Window
 from .editor import EventEditor, ExportDialog
@@ -1356,6 +1356,17 @@ def start_pane(
         color_mode: Literal['rgb', '256colors']='rgb',
 ):
     """Open the user interface with the given initial pane."""
+
+    # we can't use configobj to do validation of theme for us, because when the
+    # config is passed, we haven't loaded plugins yet. We could load plugins
+    # earlier, but then logging wouldn't work at plugin loading time.
+    # We do this early, so that logger messages still get shown in a regular way
+    theme = colors.themes.get(pane._conf['view']['theme'])
+    if theme is None:
+        logger.fatal(f'Invalid theme {pane._conf["view"]["theme"]} configured')
+        logger.fatal(f'Available themes are: {", ".join(colors.themes.keys())}')
+        raise FatalError
+
     quit_keys = quit_keys or ['q']
 
     frame = Window(
@@ -1406,7 +1417,6 @@ def start_pane(
     logger.addHandler(header_handler)
 
     frame.open(pane, callback)
-    theme = getattr(colors, pane._conf['view']['theme'])
     palette = _add_calendar_colors(
         theme, pane.collection, color_mode=color_mode,
         base='calendar', attr_template='calendar {}',

--- a/khal/ui/colors.py
+++ b/khal/ui/colors.py
@@ -107,3 +107,7 @@ light = [
 ]
 
 themes: Dict[str, List[Tuple[str, ...]]] = {'light': light, 'dark': dark}
+
+
+def register_color_theme(name: str, theme: List[Tuple[str, ...]]):
+    themes[name] = theme


### PR DESCRIPTION
With this PR we support plugins that provide color themes. 

A first example plugin implementing a gruvbox plugin can be found here: here https://github.com/geier/khal_gruvbox
![image](https://github.com/pimutils/khal/assets/275330/766d332e-d52c-4114-a4f3-052de836bc75)
