### PR TITLE
no more warnings on palette entries in config

### DIFF
--- a/khal/settings/settings.py
+++ b/khal/settings/settings.py
@@ -153,6 +153,10 @@ def get_config(
     for section, value in extras:
         if section == ():
             logger.warning(f'unknown section "{value}" in config file')
+        elif section == ('palette',):
+            # we don't validate the palette section, because there is no way to
+            # automatically extract valid attributes from the ui module
+            continue
         else:
             section = sectionize(section)
             logger.warning(

--- a/khal/settings/settings.py
+++ b/khal/settings/settings.py
@@ -161,12 +161,6 @@ def get_config(
             section = sectionize(section)
             logger.warning(
                 f'unknown key or subsection "{value}" in section "{section}"')
-
-            deprecated = [{'value': 'default_command', 'section': 'default'}]
-            for d in deprecated:
-                if (value == d['value']) and (section == d['section']):
-                    logger.warning(f'Key "{value}" in section "{section}" was '
-                                   'deprecated. See the FAQ to find out when and why!')
     return user_config
 
 


### PR DESCRIPTION
With the support of config based overriding of the active theme, the settings module would print warnings for those "extra" values in the config file.

Also remove some warning about long deprecated settings in the config file.