### PR TITLE
make ikhal work with urwid 2.4.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ may want to subscribe to `GitHub's tag feed
 not released yet
 
 * UPDATED REQUIREMENT urwid is now required >= 2.1.0
+* FIX support urwid 2.4.2
 * optimization in ikhal when editing events in the far future or past
 * FIX an issue in ikhal with updating the view of the event list after editing
   an event

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -116,7 +116,7 @@ class DateEdit(urwid.WidgetWrap):
         monthdisplay: Literal['firstday', 'firstfullweek']='firstday',
         keybindings: Optional[Dict[str, List[str]]] = None,
     ) -> None:
-        datewidth = len(startdt.strftime(dateformat)) + 1
+        datewidth = len(startdt.strftime(dateformat))
         self._dateformat = dateformat
         if startdt is None:
             startdt = dt.date.today()


### PR DESCRIPTION
There seem to be no issues with older versions of urwid.