### PR TITLE
In case alpha value exists remove it for urwid.

### DIFF
--- a/khal/cli.py
+++ b/khal/cli.py
@@ -175,7 +175,7 @@ def build_collection(conf, selection):
                     'color': cal['color'],
                     'priority': cal['priority'],
                     'ctype': cal['type'],
-                    'addresses': cal['addresses'],
+                    'addresses': cal['addresses'] if 'addresses' in cal else '',
                 }
         collection = khalendar.CalendarCollection(
             calendars=props,

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -1321,6 +1321,14 @@ def _add_calendar_colors(
             color = collection.default_color
         else:
             color = cal['color']
+
+        # In case the color contains an alpha value, remove it for urwid.
+        # eg '#RRGGBBAA' -> '#RRGGBB' and '#RGBA' -> '#RGB'.
+        if len(color) == 9:
+            color = color[0:7]
+        elif len(color) == 5:
+            color = color[0:4]
+
         entry = _urwid_palette_entry(
             attr_template.format(cal['name']),
             color,


### PR DESCRIPTION
I don't know what is in the iCal spec, but I expect an extra check for if the color includes the alpha and then removing it cannot be harmful. 

As far as I know, there is clients like SOGO that set and alpha value and this would crash urwid.