### PR TITLE
Update the date and time when pressing Alt+Enter or Page Up/Down in edit widget

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -55,3 +55,4 @@ Matthew Rademaker - matthew.rademaker [at] gmail [dot] com
 Valentin Iovene - val [at] too [dot] gy
 Julian Wollrath
 Mattori Birnbaum - me [at] mattori [dot] com - https://mattori.com
+Pi R

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -32,6 +32,8 @@ not released yet
   `?` for tentative); partication status is shown for the email addresses
   configured for the event's calendar
 * NEW support for color theme, command, and formatter plugins
+* FIX an issue where ikhal would forget changes to time or date fields if you
+  left the field with page up/down or meta+enter
 
 0.11.2
 ======

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -610,10 +610,11 @@ class EventEditor(urwid.WidgetWrap):
             return None
         else:
             self._abort_confirmed = False
+        return_value = super().keypress(size, key)
         if key in self.pane._conf['keybindings']['save']:
             self.save(None)
             return None
-        return super().keypress(size, key)
+        return return_value
 
 
 WEEKDAYS = ['MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU']  # TODO use locale and respect weekdaystart

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -138,7 +138,7 @@ class DateTimeWidget(ExtendedEdit):
             return None
 
         if (
-                key in ['up', 'down', 'tab', 'shift tab'] or
+                key in ['up', 'down', 'tab', 'shift tab', 'page up', 'page down'] or
                 (key in ['right'] and self.edit_pos >= len(self.edit_text)) or
                 (key in ['left'] and self.edit_pos == 0)):
             # when leaving the current Widget we check if currently
@@ -436,7 +436,7 @@ class ValidatedEdit(urwid.WidgetWrap):
 
     def keypress(self, size, key):
         if (
-                key in ['up', 'down', 'tab', 'shift tab'] or
+                key in ['up', 'down', 'tab', 'shift tab', 'page up', 'page down'] or
                 (key in ['right'] and self.edit_pos >= len(self.edit_text)) or
                 (key in ['left'] and self.edit_pos == 0)):
             if not self._validate():

--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -138,7 +138,8 @@ class DateTimeWidget(ExtendedEdit):
             return None
 
         if (
-                key in ['up', 'down', 'tab', 'shift tab', 'page up', 'page down'] or
+                key in ['up', 'down', 'tab', 'shift tab',
+                    'page up', 'page down', 'meta enter'] or
                 (key in ['right'] and self.edit_pos >= len(self.edit_text)) or
                 (key in ['left'] and self.edit_pos == 0)):
             # when leaving the current Widget we check if currently
@@ -436,7 +437,8 @@ class ValidatedEdit(urwid.WidgetWrap):
 
     def keypress(self, size, key):
         if (
-                key in ['up', 'down', 'tab', 'shift tab', 'page up', 'page down'] or
+                key in ['up', 'down', 'tab', 'shift tab',
+                    'page up', 'page down', 'meta enter'] or
                 (key in ['right'] and self.edit_pos >= len(self.edit_text)) or
                 (key in ['left'] and self.edit_pos == 0)):
             if not self._validate():


### PR DESCRIPTION
This PR aims to fix issues #1274 and #1345

The keypress methods in DateTimeWidget and ValidatedEdit did not account for leaving the field by pressing page up/down or meta+enter. I've added these.

Also, the keypress method of EventEditor did not propagate a keypress of 'meta enter' to its children (i.e. the time and date fields). Therefore, they were not able to update the event before the EventEditor closed. I've changed the order of the calls. I'm not 100% confident about my understanding of urwid keypress hierarchy, so I've made the conservative choice to save the return value of `super().keypress(size, key)` and return that after saving (i.e. where it originally was).

The reference to 'meta enter' should probably be replaced by referring to the proper keybinding, but I'm not entirely sure how those work.