### PR TITLE
issue:#1229 Add multi-keyword search

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -57,3 +57,4 @@ Julian Wollrath
 Mattori Birnbaum - me [at] mattori [dot] com - https://mattori.com
 Pi R
 Alnoman Kamil - noman [at] kamil [dot] gr - https://kamil.gr
+Johan XU - xujohan [at] outlook [dot] fr

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,29 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
+####################################
+Added Multi-Keyword Search Capability
+
+Support for multi-keyword search:
+The search in command cli.py has been updated to accept a list of search terms 
+(SEARCH_STRINGS) instead of a single term (SEARCH_STRING). This allows users 
+to search for events matching one or more specified keywords.
+
+Key Changes:
+
+Replaced search_string argument:
+The single search_string argument has been replaced with search_strings, 
+enabling variable-length keyword input (nargs=-1).
+Each search term is processed in a loop, and matching results are added to a 
+unified set of events.
+
+Consolidation of search results:
+Events matching each keyword are combined using a set (all_events) to eliminate 
+duplicates.
+A new event_set is introduced to ensure that events with identical descriptions 
+are displayed only once.
+The final results are sorted and displayed.
+
 0.11.4
 ======
 not released yet

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -1018,3 +1018,29 @@ def test_list_now(runner, tmpdir):
 
     result = runner.invoke(main_khal, ['list', 'now'])
     assert not result.exception
+
+def test_multi_keyword_search(runner):
+    """
+    Test the multi-keyword search functionality with event deduplication.
+    """
+    runner = runner()
+    
+    result = runner.invoke(main_khal, "new 14.12.2024 10:00-11:00 meeting conference".split())
+    assert not result.exception
+    result = runner.invoke(main_khal, "new 14.12.2024 12:00-13:00 birthday".split())
+    assert not result.exception
+    result = runner.invoke(main_khal, "new 14.12.2024 10:00-11:00 duplicate meeting".split())
+    assert not result.exception
+
+    search_args = ['search', 'meeting', 'conference']
+    result = runner.invoke(main_khal, search_args)
+
+    expected_output = [
+        "14.12.2024 10:00-11:00: meeting conference",
+        "14.12.2024 10:00-11:00 duplicate meeting"
+    ]
+    output_lines = result.output.strip().split('\n')
+    assert sorted(output_lines) == sorted(expected_output), (
+        f"Expected: {expected_output}, Got: {output_lines}"
+    )
+    assert not result.exception


### PR DESCRIPTION
Added Multi-Keyword Search Capability

Support for multi-keyword search:
The search in command cli.py has been updated to accept a list of search terms 
(SEARCH_STRINGS) instead of a single term (SEARCH_STRING). This allows users 
to search for events matching one or more specified keywords.

Key Changes:

Replaced search_string argument:
The single search_string argument has been replaced with search_strings, 
enabling variable-length keyword input (nargs=-1).
Each search term is processed in a loop, and matching results are added to a 
unified set of events.

Consolidation of search results:
Events matching each keyword are combined using a set (all_events) to eliminate 
duplicates.
A new event_set is introduced to ensure that events with identical descriptions 
are displayed only once.
The final results are sorted and displayed.