### PR TITLE
ui:Set default value to timedelta arg in add_alarm()

### DIFF
--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -562,7 +562,7 @@ class AlarmsEditor(urwid.WidgetWrap):
         """clear the alarm list"""
         self.pile.contents.clear()
 
-    def add_alarm(self, button, timedelta: Optional[dt.timedelta]):
+    def add_alarm(self, button, timedelta: Optional[dt.timedelta] = None):
         if timedelta is None:
             timedelta = dt.timedelta(0)
         self.pile.contents.insert(


### PR DESCRIPTION
Fixes #1338: _Adding an alarm in ikhal causes a crash_

The original author of the issue had the same fix.  
At least I learned how to setup the debugger to work with an interactive terminal UI!