### PR TITLE
support python 3.13 (#1388), limit icalendar version < 6 (#1361)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -33,6 +33,7 @@ not released yet
 * NEW support for color theme, command, and formatter plugins
 * FIX an issue where ikhal would forget changes to time or date fields if you
   left the field with page up/down or meta+enter
+* NEW support python 3.13
 
 0.11.3
 ======

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,11 @@ classifiers = [
   "Topic :: Communications",
   "Topic :: Utilities",
 ]
-requires-python = ">=3.8,<3.13"
+requires-python = ">=3.8,<3.14"
 dependencies = [
     "click>=3.2",
     "click_log>=0.2.0",
-    "icalendar>=4.0.3",
+    "icalendar>=4.0.3,<6.0.0",
     "urwid>=2.6.15",
     "pyxdg",
     "pytz",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py38,py39,py310,py311,py312}-tests,py39-tests-{pytz2018.7,pytz_latest}
+envlist = {py38,py39,py310,py311,py312,py313}-tests,py39-tests-{pytz2018.7,pytz_latest}
 skip_missing_interpreters = True
 
 [testenv]
@@ -24,6 +24,7 @@ python =
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
Bump Python version, tested on Archlinux with Python 3.13.1 .

I had to limit the icalendar version to version 5.0.13 because of unresolved issue #1361 .
