### PR TITLE
Trigger test failure

### DIFF
--- a/tests/event_test.py
+++ b/tests/event_test.py
@@ -673,7 +673,7 @@ def test_create_timezone_in_future():
 
 now = dt.datetime.now()
 min_value = now - dt.timedelta(days=3560)
-max_value = now + dt.timedelta(days=3560)
+max_value = now + dt.timedelta(days=5560)
 AMSTERDAM = pytz.timezone('Europe/Amsterdam')
 
 


### PR DESCRIPTION
This PR is not meant to be merged, but you should investigate test failures.

It seems, dates beyond 2037 break the code.
This could be from the year-2038 overflow of signed integers of UNIX epoch values.

Without this patch, tests only start to fail after FTBFS-2028-03-12.