### PR TITLE
Show organizer field in editor and add a default config option

### DIFF
--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -355,6 +355,11 @@ class Event:
         else:
             return email
 
+    def update_organizer(self, organizer: str) -> None:
+        if len(self.attendees) > 0:
+            email = organizer.lstrip("MAILTO:").lower()
+            self._vevents[self.ref]['ORGANIZER'] = f"MAILTO:{email}"
+
     @property
     def url(self) -> str:
         if 'URL' not in self._vevents[self.ref]:

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -76,6 +76,10 @@ type = option('calendar', 'birthdays', 'discover', default='calendar')
 # belongs to the user.
 addresses = force_list(default='')
 
+# The organizer email to use when inviting attendees.
+# 'MAILTO:' is automatically prepended to the email address.
+organizer = string(default=None)
+
 [sqlite]
 # khal stores its internal caching database here, by default this will be in the *$XDG_DATA_HOME/khal/khal.db* (this will most likely be *~/.local/share/khal/khal.db*).
 path = expand_db_path(default=None)

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -197,6 +197,10 @@ quit = force_list(default=list('q', 'Q'))
 # new event). If this is not set, such operations require an explicit value.
 default_calendar = string(default=None)
 
+# The organizer email to use when inviting attendees.
+# 'MAILTO:' is automatically prepended to the email address.
+default_organizer = string(default=None)
+
 # By default, khal displays only dates with events in `list` or `calendar`
 # view.  Setting this to *True* will show all days, even when there is no event
 # scheduled on that day.

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -377,6 +377,7 @@ class EventEditor(urwid.WidgetWrap):
         self.description = event.description
         self.location = event.location
         self.attendees = event.attendees
+        self.organizer = event.organizer
         self.categories = event.categories
         self.url = event.url
         self.startendeditor = StartEndEditor(
@@ -429,6 +430,15 @@ class EventEditor(urwid.WidgetWrap):
         self.url = urwid.AttrMap(ExtendedEdit(
             caption=('caption', 'URL:         '), edit_text=self.url), 'edit', 'edit focus',
         )
+        self.organizer = urwid.AttrMap(
+            ExtendedEdit(
+                caption=("caption", "Organizer:   "), edit_text=self.organizer
+            ),
+            "edit",
+            "edit focus",
+        self.organizer = urwid.AttrMap(ExtendedEdit(
+            caption=("caption", "Organizer:   "), edit_text=self.organizer), "edit", "edit focus",
+        )
         self.alarmseditor: AlarmsEditor = AlarmsEditor(self.event)
         self.pile = NListBox(urwid.SimpleFocusListWalker([
             self.summary,
@@ -442,6 +452,7 @@ class EventEditor(urwid.WidgetWrap):
             self.url,
             divider,
             self.attendees,
+            self.organizer,
             divider,
             self.startendeditor,
             self.recurrenceeditor,
@@ -513,6 +524,8 @@ class EventEditor(urwid.WidgetWrap):
             return True
         if get_wrapped_text(self.attendees) != self.event.attendees:
             return True
+        if get_wrapped_text(self.organizer) != self.event.organizer:
+            return True
         if self.startendeditor.changed or self.calendar_chooser.changed:
             return True
         if self.recurrenceeditor.changed:
@@ -527,6 +540,7 @@ class EventEditor(urwid.WidgetWrap):
         self.event.update_location(get_wrapped_text(self.location))
         self.event.update_attendees(get_wrapped_text(self.attendees).split(','))
         self.event.update_categories(get_wrapped_text(self.categories).split(','))
+        self.event.update_organizer(get_wrapped_text(self.organizer))
         self.event.update_url(get_wrapped_text(self.url))
 
         if self.startendeditor.changed:

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -431,9 +431,16 @@ class EventEditor(urwid.WidgetWrap):
             caption=('caption', 'URL:         '), edit_text=self.url), 'edit', 'edit focus',
         )
         if len(self.organizer) == 0:
-            default_organizer = self._conf["default"]["default_organizer"]
-            if default_organizer:
-                self.organizer = default_organizer
+            default_calendar = self.event.calendar
+            account_organizer = self._conf["calendars"][default_calendar].get(
+                "organizer", default=None
+            )
+            if account_organizer:
+                self.organizer = account_organizer
+            else:
+                default_organizer = self._conf["default"]["default_organizer"]
+                if default_organizer:
+                    self.organizer = default_organizer
         self.organizer = urwid.AttrMap(ExtendedEdit(
             caption=("caption", "Organizer:   "), edit_text=self.organizer), "edit", "edit focus",
         )

--- a/khal/ui/editor.py
+++ b/khal/ui/editor.py
@@ -430,12 +430,10 @@ class EventEditor(urwid.WidgetWrap):
         self.url = urwid.AttrMap(ExtendedEdit(
             caption=('caption', 'URL:         '), edit_text=self.url), 'edit', 'edit focus',
         )
-        self.organizer = urwid.AttrMap(
-            ExtendedEdit(
-                caption=("caption", "Organizer:   "), edit_text=self.organizer
-            ),
-            "edit",
-            "edit focus",
+        if len(self.organizer) == 0:
+            default_organizer = self._conf["default"]["default_organizer"]
+            if default_organizer:
+                self.organizer = default_organizer
         self.organizer = urwid.AttrMap(ExtendedEdit(
             caption=("caption", "Organizer:   "), edit_text=self.organizer), "edit", "edit focus",
         )


### PR DESCRIPTION
This makes the organizer field configurable in the editor, populating it from the event if its set.

If the value is not set, and there is at least one attendee, then it sets the organizer field to the value in the config field `organizer` from the default calendar, or `default_organizer`.

I needed this so that my Nextcloud instance will send email invites to attendees, it requires the organizer field to be set and match the email of the account (https://github.com/nextcloud/server/issues/17810#issuecomment-767732407).