### PR TITLE
Bump required version of setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ khal = "khal.cli:main_khal"
 ikhal = "khal.cli:main_ikhal"
 
 [build-system]
-requires = ["setuptools>=64", "setuptools_scm>=8"]
+requires = ["setuptools>=77", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
Older versions are incompatible since the format for the project.licence field has recently changed.

Fixes: https://github.com/pimutils/khal/issues/1402