### PR TITLE
Remove obsolete tests block

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,12 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
+0.13.1
+======
+unreleased
+
+* CHANGE the ``pkg_resources`` library is no longer required.
+
 0.13.0
 ======
 2025-04-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ test = [
   "hypothesis",
   "packaging",
   "vdirsyncer",
-  "setuptools",  # python > 3.12 does not ship pkg_resources anymore
   "importlib-metadata; python_version <= '3.9'",  # importlib.metadata is in stdlib since 3.10
 ]
 docs = [

--- a/tests/backend_test.py
+++ b/tests/backend_test.py
@@ -2,7 +2,6 @@ import datetime as dt
 from operator import itemgetter
 
 import icalendar
-import pkg_resources
 import pytest
 
 from khal.khalendar import backend
@@ -598,13 +597,6 @@ def test_check_support():
     ical = icalendar.Calendar.from_ical(event_rrule_this_and_prior)
     with pytest.raises(UpdateFailed):
         [backend.check_support(event, '', '') for event in ical.walk()]
-
-    # icalendar 3.9.2 changed how it deals with unsupported components
-    if pkg_resources.get_distribution('icalendar').parsed_version \
-       <= pkg_resources.parse_version('3.9.1'):
-        ical = icalendar.Calendar.from_ical(event_rdate_period)
-        with pytest.raises(UpdateFailed):
-            [backend.check_support(event, '', '') for event in ical.walk()]
 
 
 def test_check_support_rdate_no_values():


### PR DESCRIPTION
This code verified compatibility with icalendar <= 3.9.1, but we now only support icalendar >= 6.0.0.