### PR TITLE
delete temporarily created ics files

### DIFF
--- a/khal/khalendar/vdir.py
+++ b/khal/khalendar/vdir.py
@@ -156,12 +156,16 @@ def atomic_write(dest, overwrite=False):
         file.flush()
         file.close()
 
-        if overwrite:
-            os.rename(src, dest)
-        else:
-            os.link(src, dest)
-            os.unlink(src)
-
+        try:
+            if overwrite:
+                os.rename(src, dest)
+            else:
+                os.link(src, dest)
+        except OSError:
+            raise
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(src)
 
 class VdirBase:
     item_class = Item


### PR DESCRIPTION
I noticed `khal` creates temporary files during the import and doesn't clean them.

`os.link` (renaming from temp file to destination) raises an exception when there's already an event with the same uid. This pollutes my calendar folder with `uid.ics-(some-random-letters)` files.

This PR unlinks those files that failed for updating the calendar events.