### PR TITLE
Improve usability of `khal list -d absent`

### DIFF
--- a/khal/cli_utils.py
+++ b/khal/cli_utils.py
@@ -59,8 +59,13 @@ def multi_calendar_select(ctx, include_calendars, exclude_calendars):
         selection.update(include_calendars)
     elif exclude_calendars:
         selection.update(ctx.obj['conf']['calendars'].keys())
-        for value in exclude_calendars:
-            selection.remove(value)
+        for cal_name in exclude_calendars:
+            if cal_name not in selection:
+                raise click.BadParameter(
+                    f'Unknown calendar {cal_name}, run `khal printcalendars` '
+                    'to get a list of all configured calendars.'
+                )
+            selection.discard(cal_name)
 
     return selection or None
 


### PR DESCRIPTION
If a user provides an absent calendar name to be filtered out with `khal list -d`, an error is raised and the call stack is thrown at the user (24 lines of internals with a final "KeyError: 'absent').

To improve the usability, this improvement catches this situation and properly tells the user what happend and how to remedy the situation, just like `-a absent` would do.