### PR TITLE
Add main category and icon to khal.desktop

### DIFF
--- a/misc/khal.desktop
+++ b/misc/khal.desktop
@@ -1,8 +1,9 @@
 [Desktop Entry]
 Name=ikhal
-Categories=Calendar;ConsoleOnly;
+Categories=Office;Calendar;ConsoleOnly;
 GenericName=Calendar application
 Comment=Terminal CLI calendar application
+Icon=x-office-calendar
 Exec=ikhal
 Terminal=true
 Type=Application


### PR DESCRIPTION
This pull request adds the "Office" category and the "x-office-calendar" icon to the khal.desktop file.

* Adding a category fixes the entry being placed in the "Lost and Found" category in KDE Plasma, maybe other desktops?
* Adding an icon makes it look good in the menus :-) I've chosen an icon that is available in most icon themes. It is an icon for a file type instead of an application, but it should look good enough.