### PR TITLE
add 'current-date' attribute to events

### DIFF
--- a/khal/khalendar/event.py
+++ b/khal/khalendar/event.py
@@ -645,6 +645,8 @@ class Event:
         attributes["end-date-long"] = self.end_local.strftime(self._locale['longdateformat'])
         attributes["end-time"] = self.end_local.strftime(self._locale['timeformat'])
 
+        attributes["current-date"] = relative_to_start.strftime(self._locale['dateformat'])
+
         attributes["duration"] = timedelta2str(self.duration)
 
         # should only have time attributes at this point (start/end)

--- a/khal/utils.py
+++ b/khal/utils.py
@@ -221,7 +221,8 @@ CONTENT_ATTRIBUTES = ['start', 'start-long', 'start-date', 'start-date-long',
                       'start-style', 'end-style', 'to-style', 'start-end-time-style',
                       'end-necessary', 'end-necessary-long', 'repeat-symbol', 'repeat-pattern',
                       'title', 'organizer', 'description', 'location', 'all-day', 'categories',
-                      'uid', 'url', 'calendar', 'calendar-color', 'status', 'cancelled']
+                      'uid', 'url', 'calendar', 'calendar-color', 'status', 'cancelled',
+                      'current-date']
 
 
 def json_formatter(fields):


### PR DESCRIPTION
When printing multi-day events through 'khal list --json', each day gets its own entry. However there is no indication which event belongs to which day. The user would manually need to recalculate it.

Add a new attribute which references the specific day of a multi-day event that is printed.