### PR TITLE
fix: replace bare except with except Exception in backend.py

### DIFF
--- a/khal/khalendar/backend.py
+++ b/khal/khalendar/backend.py
@@ -98,7 +98,7 @@ class SQLiteDb:
         self._at_once = True
         try:
             yield self
-        except:
+        except Exception:
             raise
         else:
             self.conn.commit()


### PR DESCRIPTION
## Summary

Replaces bare `except:` with `except Exception:` in `khal/khalendar/backend.py` (line 101).

## Why

Bare `except:` catches `SystemExit` and `KeyboardInterrupt`, which can mask Ctrl+C handling and make debugging harder.