### PR TITLE
pyproject: support Python 3.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "3.15.0-beta.2"]
         tox-test: ["default"]
 
     steps:

--- a/khal/__init__.py
+++ b/khal/__init__.py
@@ -39,3 +39,23 @@ __author_email__ = "khal@lostpackets.de"
 __description__ = "A standards based terminal calendar"
 __license__ = "Expat/MIT, see COPYING"
 __homepage__ = "https://lostpackets.de/khal/"
+
+
+# Monkeypatch _strptime to support Python 3.15+ where parsing day of month (%d or %e)
+# without a year directive raises a ValueError.
+try:
+    import _strptime
+except ImportError:
+    pass
+else:
+    _orig_strptime = _strptime._strptime
+
+    def _custom_strptime(data_string, format_string):
+        has_year = "%y" in format_string or "%Y" in format_string
+        has_day = "%d" in format_string or "%e" in format_string
+        if has_day and not has_year:
+            data_string = f"{data_string} 2024"
+            format_string = f"{format_string} %Y"
+        return _orig_strptime(data_string, format_string)
+
+    _strptime._strptime = _custom_strptime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,11 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
+  "Programming Language :: Python :: 3.15",
   "Topic :: Communications",
   "Topic :: Utilities",
 ]
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.10,<3.16"
 dependencies = [
     "click>=3.2",
     "click_log>=0.2.0",


### PR DESCRIPTION
Fedora 45 is already starting to build with it.

---
Can be deferred to whenever it is wanted; I'm mostly making sure that it's actually OK here before blindly updating constraints in the Fedora package.