### PR TITLE
Fix locale ISO datetime parsing

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -59,3 +59,4 @@ Pi R
 Alnoman Kamil - noman [at] kamil [dot] gr - https://kamil.gr
 Leonardo Taccari - iamleot [at] gmail [dot] com
 Jorenar - dev [at] jorenar [dot] com - https://jorenar.com
+Khanh Le

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ may want to subscribe to `GitHub's tag feed
 ======
 unreleased
 * FIX add timezone when assigning start/end time
+* FIX parse ISO-like locale datetime formats with an empty timezone field
 
 0.14.0
 ======

--- a/khal/parse_datetime.py
+++ b/khal/parse_datetime.py
@@ -23,8 +23,8 @@
 strings to date(time) or event objects"""
 
 import datetime as dt
-import logging
 import locale
+import logging
 import re
 from calendar import isleap
 from collections.abc import Callable

--- a/khal/parse_datetime.py
+++ b/khal/parse_datetime.py
@@ -24,6 +24,7 @@ strings to date(time) or event objects"""
 
 import datetime as dt
 import logging
+import locale
 import re
 from calendar import isleap
 from collections.abc import Callable
@@ -37,6 +38,29 @@ from khal.exceptions import DateTimeParseError, FatalError
 from .custom_types import LocaleConfiguration, RRuleMapType
 
 logger = logging.getLogger("khal")
+
+
+def _locale_format_candidates(dateformat: str) -> list[str]:
+    replacements = {
+        "%c": locale.D_T_FMT,
+        "%x": locale.D_FMT,
+        "%X": locale.T_FMT,
+    }
+    expanded_format = dateformat
+    for directive, nl_item in replacements.items():
+        if directive in expanded_format:
+            expanded_format = expanded_format.replace(directive, locale.nl_langinfo(nl_item))
+
+    candidates = [dateformat]
+    if expanded_format != dateformat:
+        candidates.append(expanded_format)
+
+    if "%Z" in expanded_format:
+        without_timezone = expanded_format.replace(" %Z", "").replace("%Z", "").strip()
+        if without_timezone not in candidates:
+            candidates.append(without_timezone)
+
+    return candidates
 
 
 def timefstr(dtime_list: list[str], timeformat: str) -> dt.datetime:
@@ -80,7 +104,15 @@ def datetimefstr(
     parts = dateformat.count(" ") + 1
     dtstring = " ".join(dtime_list[0:parts])
     # only time.strptime can parse the 29th of Feb. if no year is given
-    dtstart_struct = strptime(dtstring, dateformat)
+    for candidate_format in _locale_format_candidates(dateformat):
+        try:
+            dtstart_struct = strptime(dtstring, candidate_format)
+        except ValueError:
+            pass
+        else:
+            break
+    else:
+        raise ValueError
     if (
         infer_year
         and dtstart_struct.tm_mon == 2

--- a/tests/parse_datetime_test.py
+++ b/tests/parse_datetime_test.py
@@ -1,4 +1,5 @@
 import datetime as dt
+import locale
 from collections import OrderedDict
 
 import pytest
@@ -205,6 +206,27 @@ class TestGuessDatetimefstr:
         assert (dt.datetime(2017, 1, 1, 16, 30), False) == guessdatetimefstr(
             "2017-1-1 16:30".split(), locale=locale, default_day=dt.datetime.today()
         )
+
+    def test_locale_datetime_with_empty_timezone(self, monkeypatch):
+        def nl_langinfo(item):
+            return {
+                locale.D_T_FMT: "%Y-%m-%dT%T %Z",
+                locale.D_FMT: "%Y-%m-%d",
+                locale.T_FMT: "%T",
+            }[item]
+
+        monkeypatch.setattr(locale, "nl_langinfo", nl_langinfo)
+        parsed = guessdatetimefstr(
+            ["2026-05-14T12:00:00"],
+            {
+                "timeformat": "%X",
+                "dateformat": "%x",
+                "longdateformat": "%x",
+                "datetimeformat": "%c",
+                "longdatetimeformat": "%c",
+            },
+        )
+        assert parsed == (dt.datetime(2026, 5, 14, 12), False)
 
 
 class TestGuessTimedeltafstr:


### PR DESCRIPTION
Fixes #1469.

This updates locale datetime parsing so composite locale directives are expanded through `locale.nl_langinfo()` before parsing. It also accepts the ISO-like `%c` form produced by locales such as `en_DK.utf8` when the formatted value has an empty `%Z` timezone field.

The regression test covers a locale-provided datetime format of `%Y-%m-%dT%T %Z` with an input value that omits the timezone name.

Validation:

```
. .venv-oss1856/bin/activate && py.test tests/parse_datetime_test.py -q
# 54 passed, 14 warnings
```

```
. .venv-oss1856/bin/activate
TMPDIR=$(mktemp -d)
mkdir -p "$TMPDIR/calendar" "$TMPDIR/cache"
CONFIG="$TMPDIR/config"
printf '%s\n' '[calendars]' '  [[default]]' "    path = $TMPDIR/calendar" '    color = dark magenta' '' '[locale]' 'local_timezone = Europe/Paris' 'default_timezone = Europe/Paris' '' '[sqlite]' "path = $TMPDIR/cache/khal.db" > "$CONFIG"
env -u LC_ALL LANG=en_US.utf8 LC_TIME=en_DK.utf8 khal -c "$CONFIG" printformats
env -u LC_ALL LANG=en_US.utf8 LC_TIME=en_DK.utf8 khal -c "$CONFIG" at '2026-05-14T12:00:00'
# exit 0; no critical parse error
```
