### PR TITLE
Fix crash with urwid >= 4.0.5

### DIFF
--- a/khal/ui/widgets.py
+++ b/khal/ui/widgets.py
@@ -643,8 +643,8 @@ class FocusLineBoxWidth(urwid.WidgetDecoration, urwid.WidgetWrap):
             focus_item=1,
         )
 
-        urwid.WidgetDecoration.__init__(self, widget)
         urwid.WidgetWrap.__init__(self, self._all)
+        self._original_widget = widget
 
     def render(self, size, focus):
         inner = self._all.contents[1][0]
@@ -696,7 +696,7 @@ class FocusLineBoxColor(urwid.WidgetDecoration, urwid.WidgetWrap):
         )
 
         urwid.WidgetWrap.__init__(self, self._all)
-        urwid.WidgetDecoration.__init__(self, widget)
+        self._original_widget = widget
 
     def render(self, size, focus):
         if focus:
@@ -715,7 +715,7 @@ class FocusLineBoxTop(urwid.WidgetDecoration, urwid.WidgetWrap):
         topline = urwid.AttrMap(urwid.Divider("━"), "frame")
         self._all = urwid.Pile([("flow", topline), widget], focus_item=1)
         urwid.WidgetWrap.__init__(self, self._all)
-        urwid.WidgetDecoration.__init__(self, widget)
+        self._original_widget = widget
 
     def render(self, size, focus):
         if focus:

--- a/tests/ui/test_widgets.py
+++ b/tests/ui/test_widgets.py
@@ -1,4 +1,12 @@
-from khal.ui.widgets import delete_last_word
+import pytest
+import urwid
+
+from khal.ui.widgets import (
+    FocusLineBoxColor,
+    FocusLineBoxTop,
+    FocusLineBoxWidth,
+    delete_last_word,
+)
 
 
 def test_delete_last_word():
@@ -27,3 +35,12 @@ def test_delete_last_word():
 
     for org, short, number in tests:
         assert delete_last_word(org, number) == short
+
+
+@pytest.mark.parametrize("cls", [FocusLineBoxColor, FocusLineBoxTop, FocusLineBoxWidth])
+def test_focus_line_box(cls):
+    inner = urwid.Filler(urwid.Text("test"))
+    box = cls(inner)
+    assert box.original_widget is inner
+    box.render((20, 10), focus=False)
+    box.render((20, 10), focus=True)


### PR DESCRIPTION
Reproducible when a config includes:

    [view]
    frame = width

Basically it's a diamond problem:

- WidgetDecoration.__init__() calls super().__init__()
- This resolves to WidgetWrap.__init__()
- WidgetWrap.__init__() calls WidgetWrap.__init__() without any arguments.

The MRO here is:

    FocusLineBoxWidth -> WidgetDecoration -> WidgetWrap -> … -> Widget

Fixes: https://github.com/pimutils/khal/issues/1473