### PR TITLE
docs: fix broken links in installation instructions

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -7,10 +7,10 @@ khal has been packaged for, among others: Arch Linux (stable_ and development_
 versions), Debian_, Fedora_, FreeBSD_, Guix_, and pkgsrc_ (or see repology_ for
 a more complete list).
 
-.. _stable: https://www.archlinux.org/packages/community/any/khal/
+.. _stable: https://archlinux.org/packages/extra/any/khal/
 .. _development: https://aur.archlinux.org/packages/khal-git/
 .. _Debian: https://packages.debian.org/search?keywords=khal&searchon=names
-.. _Fedora: https://admin.fedoraproject.org/pkgdb/package/rpms/khal/
+.. _Fedora: https://packages.fedoraproject.org/pkgs/khal/khal/
 .. _FreeBSD: https://www.freshports.org/deskutils/py-khal/
 .. _Guix: http://www.gnu.org/software/guix/packages/
 .. _pkgsrc: http://pkgsrc.se/time/khal
@@ -31,7 +31,7 @@ You can install the latest released version of *khal* by executing::
 
 or the latest development version by executing::
 
-     pip install git+git://github.com/pimutils/khal.git
+     pip install git+https://github.com/pimutils/khal.git
 
 This should also take care of installing all required dependencies.  If in
 doubt, do not use `sudo pip install` but install `pip install khal --user`.


### PR DESCRIPTION
Three links in the installation guide are dead. All verified with curl (old URLs return 404, new ones return 200).

| Location | Problem | Fix |
| --- | --- | --- |
| `install.rst` Arch Linux link | `[community]` repo was merged into `[extra]` in 2023; the old URL now 404s | point to `archlinux.org/packages/extra/any/khal/` |
| `install.rst` Fedora link | `admin.fedoraproject.org/pkgdb` was retired years ago | point to `packages.fedoraproject.org/pkgs/khal/khal/` |
| `install.rst` dev install command | GitHub disabled the `git://` protocol in 2022, so `pip install git+git://…` fails | use `git+https://…` |

Docs only, no behaviour change. Happy to add an `AUTHORS.txt` / `CHANGELOG.rst` entry if you'd like one for this.