### PR TITLE
ikhal: view event details in the external pager

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -59,3 +59,4 @@ Pi R
 Alnoman Kamil - noman [at] kamil [dot] gr - https://kamil.gr
 Leonardo Taccari - iamleot [at] gmail [dot] com
 Jorenar - dev [at] jorenar [dot] com - https://jorenar.com
+Mario Moura - mm [at] mariomoura [dot] com - https://mariomoura.com

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,14 @@ Package maintainers and users who have to manually update their installation
 may want to subscribe to `GitHub's tag feed
 <https://github.com/geier/khal/tags.atom>`_.
 
+0.14.2
+======
+unreleased
+
+* NEW ikhal: view the selected event's details in the external pager
+  ($PAGER, falls back to `less`), default keybinding `V`. Useful for events
+  with descriptions or attendee lists too long for the event view window.
+
 0.14.1
 ======
 2026-08-21

--- a/doc/source/usage.rst
+++ b/doc/source/usage.rst
@@ -400,6 +400,10 @@ When an event list is in focus, you can
  * duplicate the selected event, default keybinding :kbd:`p` as in duplicate
    (d was already taken)
  * export the selected event, default keybinding :kbd:`e`
+ * view the selected event's details in the external pager (``$PAGER``,
+   falling back to :command:`less`), default keybinding :kbd:`V`, useful for
+   events with descriptions or attendee lists too long for the event view
+   window
 
 In the event editor, you can
 

--- a/khal/settings/khal.spec
+++ b/khal/settings/khal.spec
@@ -162,6 +162,10 @@ view = force_list(default=list('enter'))
 # doesn't do a lot of validation, it silently disregards most invalid data.
 external_edit = force_list(default=list('meta E'))
 
+# show the currently selected event's details in the external pager ($PAGER),
+# useful for events with descriptions too long for the event view window
+pager = force_list(default=list('V'))
+
 # focus the calendar browser on today
 today = force_list(default=list('t'))
 

--- a/khal/ui/__init__.py
+++ b/khal/ui/__init__.py
@@ -835,6 +835,30 @@ class EventColumn(urwid.WidgetWrap):
         )
         self.pane.window.open(overlay)
 
+    def view_in_pager(self, event) -> None:
+        """show the event's details in the external pager"""
+        lines = [f"Title: {event.summary}"]
+        if event.organizer:
+            lines.append(f"Organizer: {event.organizer}")
+        if event.location:
+            lines.append(f"Location: {event.location}")
+        if event.categories:
+            lines.append(f"Categories: {event.categories}")
+        if event.url:
+            lines.append(f"URL: {event.url}")
+        if event.attendees:
+            lines.append("Attendees:")
+            lines.extend(f"  - {attendee}" for attendee in event.attendees.split(", "))
+        lines.append(f"Calendar: {event.calendar}")
+        if event.description:
+            lines.append("")
+            lines.append(event.description)
+        self.pane.window.loop.stop()
+        try:
+            click.echo_via_pager("\n".join(lines))
+        finally:
+            self.pane.window.loop.start()
+
     def toggle_delete(self):
         """toggle the delete status of the event in focus"""
         event = self.focus_event
@@ -976,6 +1000,8 @@ class EventColumn(urwid.WidgetWrap):
                 self.edit(self.focus_event.event)
             elif key in self._conf["keybindings"]["external_edit"]:
                 self.edit(self.focus_event.event, external_edit=True)
+            elif key in self._conf["keybindings"]["pager"]:
+                self.view_in_pager(self.focus_event.event)
             elif (
                 key in self._conf["keybindings"]["view"]
                 or self._conf["view"]["event_view_always_visible"]


### PR DESCRIPTION
The event view window clips content it cannot fit, so events with long descriptions or attendee lists are partially unreadable. Add a 'pager' keybinding (default: V) that suspends the urwid loop and shows the focused event's details via click.echo_via_pager, which respects $PAGER and falls back to less.

Notes for review: all tests pass locally (334 passed); no new test since this is in the urwid part. I considered the plugin route first, but the plugin API (commands/formatters/color themes) has no hook for ikhal key actions, so core seemed the only place for this (I may be wrong). Changelog, AUTHORS and usage docs are updated.

Closes #534
Closes #1385